### PR TITLE
feat/adds notifications service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,5 @@ package-lock.json
 /performance-tests/results/
 summary.json
 
+# For private project specific information
 personal.txt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,8 @@ Metrics/BlockLength:
     - 'config/routes.rb'
     - 'config/environments/*.rb'
     - 'lib/tasks/**/*.rake'
+    - 'db/**/*'
+    - 'db/schema.rb'
 
 # Rails
 Rails/FilePath:

--- a/app/controllers/api/v1/device_tokens_controller.rb
+++ b/app/controllers/api/v1/device_tokens_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class DeviceTokensController < ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def create
+        device_token = current_api_v1_profile.device_tokens.find_or_initialize_by(
+          token: device_token_params[:token]
+        )
+
+        device_token.assign_attributes(
+          platform: device_token_params[:platform],
+          device_name: device_token_params[:device_name],
+          app_version: device_token_params[:app_version],
+          active: true,
+          last_used_at: Time.current
+        )
+
+        if device_token.save
+          render json: {
+            message: 'Device registered',
+            device_token: device_token.as_json(only: %i[id platform active])
+          }, status: :ok
+        else
+          render json: {
+            errors: device_token.errors.full_messages
+          }, status: :unprocessable_content
+        end
+      end
+
+      def destroy
+        device_token = current_api_v1_profile.device_tokens.find_by(token: params[:token])
+        device_token&.deactivate!
+
+        render json: { message: 'Device unregistered' }, status: :ok
+      end
+
+      private
+
+      def device_token_params
+        params.require(:device_token).permit(:token, :platform, :device_name, :app_version)
+      end
+    end
+  end
+end

--- a/app/models/device_token.rb
+++ b/app/models/device_token.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class DeviceToken < ApplicationRecord
+  belongs_to :profile
+
+  PLATFORMS = %w[ios android web].freeze
+
+  validates :token, presence: true
+  validates :token, uniqueness: { scope: :profile_id }
+  validates :platform, presence: true, inclusion: { in: PLATFORMS }
+
+  scope :active, -> { where(active: true) }
+  scope :for_platform, ->(platform) { where(platform: platform) }
+  scope :push_capable, -> { where(platform: %w[ios android]) }
+
+  def expo_token?
+    token.start_with?('ExponentPushToken')
+  end
+
+  def web_push?
+    platform == 'web' && endpoint.present?
+  end
+
+  def touch_last_used!
+    # rubocop:disable Rails/SkipsModelValidations
+    update_column(:last_used_at, Time.current)
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def deactivate!
+    update!(active: false)
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Notification < ApplicationRecord
+  belongs_to :profile
+  belongs_to :device_token, optional: true # For push, tracks which device
+
+  TYPES = %w[daily_reminder engagement_reminder task_reminder].freeze
+  STATUSES = %w[pending sent failed].freeze
+  CHANNELS = %w[push email sms].freeze
+
+  validates :status, inclusion: { in: STATUSES }
+  validates :notification_type, inclusion: { in: TYPES }
+  validates :channel, inclusion: { in: CHANNELS }
+
+  scope :pending, -> { where(status: 'pending') }
+  scope :sent, -> { where(status: 'sent') }
+  scope :failed, -> { where(status: 'failed') }
+  scope :by_channel, ->(channel) { where(channel: channel) }
+end

--- a/app/models/notification_preference.rb
+++ b/app/models/notification_preference.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class NotificationPreference < ApplicationRecord
+  belongs_to :profile
+
+  validates :timezone, presence: true
+
+  def push_enabled?
+    push_enabled
+  end
+
+  def email_enabled?
+    email_enabled
+  end
+
+  def sms_enabled?
+    sms_enabled
+  end
+
+  def in_quiet_hours?(time = Time.current)
+    return false unless quiet_hours_start && quiet_hours_end
+
+    current_time = time.in_time_zone(timezone).strftime('%H:%M')
+    start_time = quiet_hours_start.strftime('%H:%M')
+    end_time = quiet_hours_end.strftime('%H:%M')
+
+    if start_time < end_time
+      current_time >= start_time && current_time < end_time
+    else
+      current_time >= start_time || current_time < end_time
+    end
+  end
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -7,6 +7,9 @@ class Profile < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :ai_requests, dependent: :destroy
   has_many :tickets, dependent: :destroy
+  has_many :notifications, dependent: :destroy
+  has_many :device_tokens, dependent: :destroy
+  has_one :notification_preference, dependent: :destroy
 
   validates :onboarding_status, inclusion: { in: %w[incomplete complete] }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
 
       # Job status endpoint
       get 'jobs/:id', to: 'job_status#show'
+      resources :device_tokens, only: %i[create destroy]
     end
   end
 end

--- a/db/migrate/20251202191903_create_notifications.rb
+++ b/db/migrate/20251202191903_create_notifications.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class CreateNotifications < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notifications do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.string :notification_type, null: false
+      t.string :channel, default: 'push'
+      t.string :title
+      t.string :body
+      t.jsonb :data, default: {}
+      t.string :status, default: 'pending'
+      t.datetime :scheduled_for
+      t.datetime :sent_at
+      t.text :error_message
+
+      t.timestamps
+    end
+
+    add_index :notifications, :notification_type
+    add_index :notifications, :channel
+    add_index :notifications, :status
+    add_index :notifications, :scheduled_for
+  end
+end

--- a/db/migrate/20251202212318_create_device_tokens.rb
+++ b/db/migrate/20251202212318_create_device_tokens.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateDeviceTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :device_tokens do |t|
+      t.references :profile, null: false, foreign_key: true
+
+      # Token/subscription data
+      t.string :token, null: false
+      t.string :platform, null: false
+
+      # For future Web Push support
+      t.string :endpoint
+      t.string :p256dh
+      t.string :auth
+
+      # Device metadata
+      t.string :device_name
+      t.string :app_version
+      t.boolean :active, default: true, null: false
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :device_tokens, [:profile_id, :token], unique: true
+    add_index :device_tokens, :platform
+    add_index :device_tokens, :active
+  end
+end

--- a/db/migrate/20251202213916_create_notification_preferences.rb
+++ b/db/migrate/20251202213916_create_notification_preferences.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateNotificationPreferences < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notification_preferences do |t|
+      t.references :profile, null: false, foreign_key: true
+
+      # Channel toggles
+      t.boolean :push_enabled, default: true, null: false
+      t.boolean :email_enabled, default: true, null: false
+      t.boolean :sms_enabled, default: false, null: false
+
+      # Scheduling
+      t.time :preferred_time, default: '09:00'
+      t.string :timezone, default: 'UTC'
+
+      # Scheduling
+      t.time :quiet_hours_start
+      t.time :quiet_hours_end
+
+      # Granular controls
+      # Store as JSON for flexibility without schema changes
+      t.jsonb :channel_settings
+      # Example: { "daily_reminder": { "push": true, "email": false } }
+
+      t.datetime :last_opened_app_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_06_211906) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_02_213916) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,61 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_06_211906) do
     t.index ["hash_value"], name: "index_ai_requests_on_hash_value"
     t.index ["job_type"], name: "index_ai_requests_on_job_type"
     t.index ["profile_id"], name: "index_ai_requests_on_profile_id"
+  end
+
+  create_table "device_tokens", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.string "token", null: false
+    t.string "platform", null: false
+    t.string "endpoint"
+    t.string "p256dh"
+    t.string "auth"
+    t.string "device_name"
+    t.string "app_version"
+    t.boolean "active", default: true, null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active"], name: "index_device_tokens_on_active"
+    t.index ["platform"], name: "index_device_tokens_on_platform"
+    t.index ["profile_id", "token"], name: "index_device_tokens_on_profile_id_and_token", unique: true
+    t.index ["profile_id"], name: "index_device_tokens_on_profile_id"
+  end
+
+  create_table "notification_preferences", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.boolean "push_enabled", default: true, null: false
+    t.boolean "email_enabled", default: true, null: false
+    t.boolean "sms_enabled", default: false, null: false
+    t.time "preferred_time", default: "2000-01-01 09:00:00"
+    t.string "timezone", default: "UTC"
+    t.time "quiet_hours_start"
+    t.time "quiet_hours_end"
+    t.jsonb "channel_settings"
+    t.datetime "last_opened_app_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_notification_preferences_on_profile_id"
+  end
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.string "notification_type", null: false
+    t.string "channel", default: "push"
+    t.string "title"
+    t.string "body"
+    t.jsonb "data", default: {}
+    t.string "status", default: "pending"
+    t.datetime "scheduled_for"
+    t.datetime "sent_at"
+    t.text "error_message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["channel"], name: "index_notifications_on_channel"
+    t.index ["notification_type"], name: "index_notifications_on_notification_type"
+    t.index ["profile_id"], name: "index_notifications_on_profile_id"
+    t.index ["scheduled_for"], name: "index_notifications_on_scheduled_for"
+    t.index ["status"], name: "index_notifications_on_status"
   end
 
   create_table "profiles", force: :cascade do |t|
@@ -104,6 +159,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_06_211906) do
   end
 
   add_foreign_key "ai_requests", "profiles"
+  add_foreign_key "device_tokens", "profiles"
+  add_foreign_key "notification_preferences", "profiles"
+  add_foreign_key "notifications", "profiles"
   add_foreign_key "profiles", "users"
   add_foreign_key "smart_goals", "profiles"
   add_foreign_key "tasks", "profiles"

--- a/lib/notifications/base_service.rb
+++ b/lib/notifications/base_service.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+module Notifications
+  class BaseService
+    def initialize(profile, channels: nil)
+      @profile = profile
+      @preference = profile.notification_perference
+      @channels = channels || default_channels
+    end
+
+    def call
+      return [] unless should_send?
+
+      notifications = []
+
+      @channels.each do |channel|
+        next unless channel_enabled?(channel)
+
+        case channel.to_sym
+        when :push
+          notifications.concat(send_push_notifications)
+        when :email
+          notifications << send_email_notification if email_ready?
+        end
+      end
+
+      notifications.compact
+    end
+
+    private
+
+    def should_send?
+      @preference.present? && !@preference.in_quiet_hours?
+    end
+
+    def channel_enabled?(channel)
+      @preference.channel_enabled?(notification_type, channel)
+    end
+
+    def default_channels
+      [:push]
+    end
+
+    def send_push_notifications
+      @profile.push_tokens.map do |device_token|
+        send_push_to_device(device_token)
+      end
+    end
+
+    def send_push_to_device(device_token)
+      notification = create_notification_record(:push, device_token)
+
+      Notifications::Delivery::PushService.new(
+        device_token: device_token,
+        notification: notification
+      ).deliver
+
+      notification
+    rescue StandardError => e
+      notification&.update!(status: 'failed', error_message: e.message)
+      Rails.logger.error("Push failed: #{e.message}")
+      notification
+    end
+
+    # Placeholder for future email implementation
+    def send_email_notification
+      return nil unless email_ready?
+
+      create_notification_record(:email)
+      # Notifications::Delivery::EmailService.new(...).deliver
+    end
+
+    # Placeholder for future SMS implementation
+    def send_sms_notification
+      return nil unless sms_ready?
+
+      create_notification_record(:sms)
+      # Notifications::Delivery::SmsService.new(...).deliver
+    end
+
+    def email_ready?
+      false  # Not implemented yet
+    end
+
+    def sms_ready?
+      false  # Not implemented yet
+    end
+
+    def create_notification_record(channel, device_token = nil)
+      Notification.create!(
+        profile: @profile,
+        device_token: device_token,
+        notification_type: notification_type,
+        channel: channel.to_s,
+        title: notification_title,
+        body: notification_body,
+        data: notification_data,
+        scheduled_for: Time.current
+      )
+    end
+
+    def notification_type
+      raise NotImplementedError
+    end
+
+    def notification_title
+      raise NotImplementedError
+    end
+
+    def notification_body
+      raise NotImplementedError
+    end
+
+    def notification_data
+      {}
+    end
+  end
+end

--- a/lib/notifications/daily_reminder_service.rb
+++ b/lib/notifications/daily_reminder_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Notifications
+  class DailyReminderService
+    def notification_type
+      'daily_reminder'
+    end
+
+    def notification_title
+      'Stay on Track! 💪'
+    end
+
+    def notification_body
+      "Can't accomplish your goal by not chipping away at it day by day"
+    end
+
+    def notification_data
+      {
+        type: 'daily_reminder',
+        screen: 'tasks'
+      }
+    end
+  end
+end

--- a/lib/notifications/delivery/push_service.rb
+++ b/lib/notifications/delivery/push_service.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Notifications
+  module Delivery
+    class PushService
+      EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
+
+      def initialize(device_token:, notification:, http_client: nil)
+        @device_token = device_token
+        @notification = notification
+        @http_client = http_client || default_http_client
+      end
+
+      def deliver
+        response = send_request
+
+        if response.success?
+          handle_success(response)
+        else
+          handle_failure(response)
+        end
+      end
+
+      private
+
+      def send_request
+        @http_client.new(EXPO_PUSH_URL).post(payload: payload)
+      end
+
+      def payload
+        {
+          to: @device_token.token,
+          title: @notification.title,
+          body: @notification.body,
+          data: @notification.data,
+          sound: 'default',
+          channelId: 'default'
+        }
+      end
+
+      def handle_success(response)
+        @notification.update!(status: 'sent', sent_at: Time.current)
+        @device_token.touch_last_used!
+
+        check_expo_errors(response.body)
+      end
+
+      def handle_failure(response)
+        @notification.update!(
+          status: 'failed',
+          error_message: response.body.to_s
+        )
+      end
+
+      def check_expo_errors(body)
+        return unless body.is_a?(Hash) && body['data']
+
+        error = body.dig('data', 'status')
+        return unless error == 'error'
+
+        detail = body.dig('data', 'message')
+        return unless detail&.include?('DeviceNotRegistered')
+
+        @device_token.deactivate!
+      end
+
+      def default_http_client
+        HttpClientService
+      end
+    end
+  end
+end

--- a/lib/notifications/engagement_reminder_service.rb
+++ b/lib/notifications/engagement_reminder_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Notifications
+  class EngagementReminderService
+    DAYS_THRESHOLD = 3
+
+    def should_send?
+      super && days_since_last_open >= DAYS_THRESHOLD
+    end
+
+    def notification_type
+      'engagement_reminder'
+    end
+
+    def notification_title
+      'We Miss You! 🎯'
+    end
+
+    def notification_body
+      "It's been #{days_since_last_open} days. Your goals are waiting!"
+    end
+
+    def notification_data
+      {
+        type: 'engagement_reminder',
+        screen: 'home'
+      }
+    end
+
+    private
+
+    def days_since_last_open
+      return 999 unless @profile.last_opened_app_at
+
+      (Time.current - @profile.last_opened_app_at).to_i / 1.day
+    end
+  end
+end

--- a/lib/tasks/notifications/send_notification.rake
+++ b/lib/tasks/notifications/send_notification.rake
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+namespace :notifications do
+  desc 'Send a push notification. Usage: rake notifications:send_notification[title,subtitle,body,push_token,channel]'
+  task :send_notification, %i[title subtitle body push_token channel] => :environment do |_t, args|
+    args.with_defaults(
+      title: '',
+      subtitle: '',
+      body: '',
+      push_token: '',
+      channel: 'default'
+    )
+
+    message = {
+      'to' => args[:push_token],
+      'title' => args[:title],
+      'subtitle' => args[:subtitle],
+      'body' => args[:body],
+      'channel' => args[:channel]
+    }
+
+    puts 'Sending notification with:'
+    puts "Title: #{args[:title]}"
+    puts "Subtitle: #{args[:subtitle]}"
+    puts "Body: #{args[:body]}"
+    puts "Push Token: #{args[:push_token]}"
+    puts "Channel: #{args[:channel]}"
+
+    begin
+      conn = Faraday.new(
+        url: 'https://exp.host/--/api/v2/push/send',
+        headers: {
+          'Accept' => 'application/json',
+          'Accept-encoding': 'gzip, deflate',
+          'Content-Type': 'application/json'
+        }
+      )
+      resp = conn.post do |req|
+        req.body = message.to_json
+      end
+
+      puts "Response status code: #{resp.status}"
+      puts "Response headers: #{resp.headers}"
+      puts "Response body: #{resp.body}"
+    rescue StandardError => e
+      Rails.logger.error("Notification request failed: #{e}")
+    end
+  end
+end

--- a/spec/factories/device_tokens.rb
+++ b/spec/factories/device_tokens.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :device_token do
+    association :profile
+    token { "ExponentPushToken[#{SecureRandom.hex(20)}]" }
+    platform { %w[ios android].sample }
+    device_name { 'iPhone 15 Pro' }
+    app_version { '1.0.0' }
+    active { true }
+
+    trait :inactive do
+      active { false }
+    end
+
+    trait :web do
+      platform { 'web' }
+      endpoint { 'https://push.example.com/send/token123' }
+      p256dh { SecureRandom.base64(32) }
+      auth { SecureRandom.base64(16) }
+    end
+  end
+end

--- a/spec/factories/notification_preferences.rb
+++ b/spec/factories/notification_preferences.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :notification_preference do
+    association :profile
+    push_enabled { true }
+    email_enabled { true }
+    sms_enabled { false }
+    preferred_time { '09:00' }
+    timezone { 'UTC' }
+  end
+end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :notification do
+    association :profile
+    notification_type { 'daily_reminder' }
+    channel { 'push' }
+    title { 'Daily Check-in' }
+    body { "Don't forget to review your goals today!" }
+    status { 'pending' }
+    scheduled_for { 1.hour.from_now }
+
+    trait :sent do
+      status { 'sent' }
+      sent_at { Time.current }
+    end
+
+    trait :failed do
+      status { 'failed' }
+      error_message { 'Device token expired' }
+    end
+
+    trait :email do
+      channel { 'email' }
+    end
+
+    trait :task_reminder do
+      notification_type { 'task_reminder' }
+      title { 'Task Reminder' }
+      body { 'You have pending tasks to complete' }
+    end
+  end
+end

--- a/spec/lib/notifications/daily_reminder_service_spec.rb
+++ b/spec/lib/notifications/daily_reminder_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::DailyReminderService do
+  subject(:service) { described_class.new }
+
+  describe '#notification_type' do
+    it 'returns daily_reminder' do
+      expect(service.notification_type).to eq('daily_reminder')
+    end
+  end
+
+  describe '#notification_title' do
+    it 'returns the expected title' do
+      expect(service.notification_title).to eq('Stay on Track! 💪')
+    end
+  end
+
+  describe '#notification_body' do
+    it 'returns the expected body' do
+      expect(service.notification_body).to eq("Can't accomplish your goal by not chipping away at it day by day")
+    end
+  end
+
+  describe '#notification_data' do
+    it 'returns correct type and screen' do
+      expect(service.notification_data).to eq({
+                                                type: 'daily_reminder',
+                                                screen: 'tasks'
+                                              })
+    end
+  end
+end

--- a/spec/lib/notifications/delivery/push_service_spec.rb
+++ b/spec/lib/notifications/delivery/push_service_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::Delivery::PushService do
+  subject(:service) do
+    described_class.new(
+      device_token: device_token,
+      notification: notification,
+      http_client: mock_http_client
+    )
+  end
+
+  let(:device_token) { create(:device_token) }
+  let(:notification) { create(:notification, profile: device_token.profile) }
+
+  # Mock response object
+  let(:mock_response) { instance_double(Faraday::Response, success?: true, body: {}) }
+
+  # Mock HTTP client instance
+  let(:mock_client_instance) { instance_double(HttpClientService, post: mock_response) }
+
+  # Mock HTTP client class
+  let(:mock_http_client) do
+    class_double(HttpClientService, new: mock_client_instance)
+  end
+
+  describe '#deliver' do
+    context 'when request succeeds' do
+      it 'updates notification status to sent' do
+        service.deliver
+
+        expect(notification.reload.status).to eq('sent')
+        expect(notification.sent_at).to be_present
+      end
+
+      it 'touches device token last_used_at' do
+        expect { service.deliver }.to(change { device_token.reload.last_used_at })
+      end
+
+      it 'sends correct payload to Expo API' do
+        expected_payload = {
+          to: device_token.token,
+          title: notification.title,
+          body: notification.body,
+          data: notification.data,
+          sound: 'default',
+          channelId: 'default'
+        }
+
+        service.deliver
+
+        expect(mock_client_instance).to have_received(:post).with(payload: expected_payload)
+      end
+    end
+
+    context 'when request fails' do
+      let(:mock_response) { instance_double(Faraday::Response, success?: false, body: 'Connection refused') }
+
+      it 'updates notification status to failed' do
+        service.deliver
+
+        expect(notification.reload.status).to eq('failed')
+        expect(notification.error_message).to eq('Connection refused')
+      end
+    end
+
+    context 'when Expo returns DeviceNotRegistered error' do
+      let(:error_body) do
+        { 'data' => { 'status' => 'error', 'message' => 'DeviceNotRegistered' } }
+      end
+      let(:mock_response) { instance_double(Faraday::Response, success?: true, body: error_body) }
+
+      it 'deactivates the device token' do
+        expect { service.deliver }.to change { device_token.reload.active }.from(true).to(false)
+      end
+
+      it 'still marks notification as sent' do
+        service.deliver
+
+        expect(notification.reload.status).to eq('sent')
+      end
+    end
+
+    context 'when Expo returns success without errors' do
+      let(:success_body) { { 'data' => { 'status' => 'ok' } } }
+      let(:mock_response) { instance_double(Faraday::Response, success?: true, body: success_body) }
+
+      it 'does not deactivate the device token' do
+        expect { service.deliver }.not_to(change { device_token.reload.active })
+      end
+    end
+  end
+end

--- a/spec/lib/notifications/engagement_reminder_service_spec.rb
+++ b/spec/lib/notifications/engagement_reminder_service_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::EngagementReminderService do
+  subject(:service) { described_class.new }
+
+  describe '#notification_type' do
+    it 'returns engagement_reminder' do
+      expect(service.notification_type).to eq('engagement_reminder')
+    end
+  end
+
+  describe '#notification_title' do
+    it 'returns the expected title' do
+      expect(service.notification_title).to eq('We Miss You! 🎯')
+    end
+  end
+
+  describe '#notification_data' do
+    it 'returns correct type and screen' do
+      expect(service.notification_data).to eq({
+                                                type: 'engagement_reminder',
+                                                screen: 'home'
+                                              })
+    end
+  end
+
+  describe '#notification_body' do
+    let(:profile) { create(:profile) }
+
+    before do
+      profile.notification_preference.update!(last_opened_app_at: 5.days.ago)
+      service.instance_variable_set(:@profile, profile)
+    end
+
+    it 'includes days since last open' do
+      expect(service.notification_body).to eq("It's been 5 days. Your goals are waiting!")
+    end
+  end
+
+  describe 'DAYS_THRESHOLD' do
+    it 'is set to 3 days' do
+      expect(described_class::DAYS_THRESHOLD).to eq(3)
+    end
+  end
+
+  describe '#days_since_last_open' do
+    let(:profile) { create(:profile) }
+
+    before do
+      service.instance_variable_set(:@profile, profile)
+    end
+
+    context 'when user has opened the app recently' do
+      before { profile.notification_preference.update!(last_opened_app_at: 2.days.ago) }
+
+      it 'returns the number of days' do
+        expect(service.send(:days_since_last_open)).to eq(2)
+      end
+    end
+
+    context 'when user has never opened the app' do
+      it 'returns 999 as fallback' do
+        expect(service.send(:days_since_last_open)).to eq(999)
+      end
+    end
+
+    context 'when user opened app long ago' do
+      before { profile.notification_preference.update!(last_opened_app_at: 10.days.ago) }
+
+      it 'returns the correct number of days' do
+        expect(service.send(:days_since_last_open)).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/models/device_token_spec.rb
+++ b/spec/models/device_token_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DeviceToken, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+  end
+
+  describe 'validations' do
+    subject { create(:device_token) }
+
+    it { is_expected.to validate_presence_of(:token) }
+    it { is_expected.to validate_uniqueness_of(:token).scoped_to(:profile_id) }
+    it { is_expected.to validate_presence_of(:platform) }
+    it { is_expected.to validate_inclusion_of(:platform).in_array(DeviceToken::PLATFORMS) }
+  end
+
+  describe 'scopes' do
+    let(:profile) { create(:profile) }
+    let!(:active_ios) { create(:device_token, profile: profile, platform: 'ios', active: true) }
+    let!(:active_android) { create(:device_token, profile: profile, platform: 'android', active: true) }
+    let!(:inactive_android) { create(:device_token, :inactive, profile: profile, platform: 'android') }
+    let!(:web_token) { create(:device_token, :web, profile: profile) }
+
+    describe '.active' do
+      it 'returns only active tokens' do
+        expect(described_class.active).to contain_exactly(active_ios, active_android, web_token)
+      end
+    end
+
+    describe '.for_platform' do
+      it 'returns tokens for specified platform' do
+        expect(described_class.for_platform('ios')).to contain_exactly(active_ios)
+      end
+    end
+
+    describe '.push_capable' do
+      it 'returns only ios and android tokens' do
+        expect(described_class.push_capable).to contain_exactly(active_ios, active_android, inactive_android)
+      end
+    end
+  end
+
+  describe '#expo_token?' do
+    it 'returns true for Expo push tokens' do
+      token = build(:device_token, token: 'ExponentPushToken[abc123]')
+      expect(token.expo_token?).to be true
+    end
+
+    it 'returns false for non-Expo tokens' do
+      token = build(:device_token, token: 'fcm_token_123')
+      expect(token.expo_token?).to be false
+    end
+  end
+
+  describe '#web_push?' do
+    it 'returns true for web platform with endpoint' do
+      token = build(:device_token, :web)
+      expect(token.web_push?).to be true
+    end
+
+    it 'returns false for non-web platform' do
+      token = build(:device_token, platform: 'ios')
+      expect(token.web_push?).to be false
+    end
+  end
+
+  describe '#deactivate!' do
+    it 'sets active to false' do
+      token = create(:device_token, active: true)
+      token.deactivate!
+      expect(token.reload.active).to be false
+    end
+  end
+end

--- a/spec/models/notification_preference_spec.rb
+++ b/spec/models/notification_preference_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NotificationPreference, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:timezone) }
+  end
+
+  describe '#in_quiet_hours?' do
+    let(:preference) { build(:notification_preference, timezone: 'UTC') }
+
+    context 'when quiet hours are not set' do
+      it 'returns false' do
+        preference.quiet_hours_start = nil
+        preference.quiet_hours_end = nil
+        expect(preference.in_quiet_hours?).to be false
+      end
+    end
+
+    context 'with normal quiet hours (e.g., 22:00-08:00 overnight)' do
+      before do
+        preference.quiet_hours_start = Time.zone.parse('22:00')
+        preference.quiet_hours_end = Time.zone.parse('08:00')
+      end
+
+      it 'returns true during quiet hours (late night)' do
+        time = Time.zone.parse('23:30')
+        expect(preference.in_quiet_hours?(time)).to be true
+      end
+
+      it 'returns true during quiet hours (early morning)' do
+        time = Time.zone.parse('06:00')
+        expect(preference.in_quiet_hours?(time)).to be true
+      end
+
+      it 'returns false outside quiet hours' do
+        time = Time.zone.parse('12:00')
+        expect(preference.in_quiet_hours?(time)).to be false
+      end
+    end
+
+    context 'with daytime quiet hours (e.g., 09:00-17:00)' do
+      before do
+        preference.quiet_hours_start = Time.zone.parse('09:00')
+        preference.quiet_hours_end = Time.zone.parse('17:00')
+      end
+
+      it 'returns true during quiet hours' do
+        time = Time.zone.parse('12:00')
+        expect(preference.in_quiet_hours?(time)).to be true
+      end
+
+      it 'returns false outside quiet hours' do
+        time = Time.zone.parse('20:00')
+        expect(preference.in_quiet_hours?(time)).to be false
+      end
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notification, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_inclusion_of(:status).in_array(Notification::STATUSES) }
+    it { is_expected.to validate_inclusion_of(:notification_type).in_array(Notification::TYPES) }
+    it { is_expected.to validate_inclusion_of(:channel).in_array(Notification::CHANNELS) }
+  end
+
+  describe 'scopes' do
+    let!(:pending_notification) { create(:notification, status: 'pending', channel: 'push') }
+    let!(:sent_notification) { create(:notification, :sent, channel: 'push') }
+    let!(:failed_notification) { create(:notification, :failed, channel: 'push') }
+    let!(:email_notification) { create(:notification, :email, status: 'pending') }
+
+    describe '.pending' do
+      it 'returns only pending notifications' do
+        expect(described_class.pending).to contain_exactly(pending_notification, email_notification)
+      end
+    end
+
+    describe '.sent' do
+      it 'returns only sent notifications' do
+        expect(described_class.sent).to contain_exactly(sent_notification)
+      end
+    end
+
+    describe '.failed' do
+      it 'returns only failed notifications' do
+        expect(described_class.failed).to contain_exactly(failed_notification)
+      end
+    end
+
+    describe '.by_channel' do
+      it 'returns notifications by channel' do
+        expect(described_class.by_channel('email')).to contain_exactly(email_notification)
+      end
+    end
+  end
+end

--- a/spec/requests/device_tokens_spec.rb
+++ b/spec/requests/device_tokens_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'DeviceTokens', type: :request do
+  let(:user) { create(:user) }
+  let(:profile) { create(:profile, user: user) }
+
+  before { sign_in user }
+
+  describe 'POST /api/v1/device_tokens' do
+    let(:valid_params) do
+      {
+        device_token: {
+          token: 'ExponentPushToken[abc123]',
+          platform: 'ios',
+          device_name: 'iPhone 15',
+          app_version: '1.2.0'
+        }
+      }
+    end
+
+    it 'registers a new device token' do
+      expect do
+        post '/api/v1/device_tokens', params: valid_params
+      end.to change(DeviceToken, :count).by(1)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['message']).to eq('Device registered')
+    end
+
+    it 'updates existing token if already registered' do
+      create(:device_token, profile: profile, token: 'ExponentPushToken[abc123]', app_version: '1.0.0')
+
+      expect do
+        post '/api/v1/device_tokens', params: valid_params
+      end.not_to change(DeviceToken, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(DeviceToken.last.app_version).to eq('1.2.0')
+    end
+
+    it 'returns errors for invalid platform' do
+      invalid_params = valid_params.deep_dup
+      invalid_params[:device_token][:platform] = 'invalid'
+
+      post '/api/v1/device_tokens', params: invalid_params
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors']).to include('Platform is not included in the list')
+    end
+  end
+
+  describe 'DELETE /api/v1/device_tokens/:id' do
+    let!(:device_token) { create(:device_token, profile: profile) }
+
+    it 'deactivates the device token' do
+      delete "/api/v1/device_tokens/#{device_token.id}", params: { token: device_token.token }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body['message']).to eq('Device unregistered')
+      expect(device_token.reload.active).to be false
+    end
+
+    it 'returns success even if token not found' do
+      delete '/api/v1/device_tokens/0', params: { token: 'nonexistent' }
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when not authenticated' do
+    before { sign_out user }
+
+    it 'returns unauthorized for create' do
+      post '/api/v1/device_tokens', params: { device_token: { token: 'test', platform: 'ios' } }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'returns unauthorized for destroy' do
+      delete '/api/v1/device_tokens/1', params: { token: 'test' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+end


### PR DESCRIPTION
[11 tools called]

Based on the commits and the code I reviewed, here's the PR description:

---

**Summary**

- Added a notification system with models, services, and API endpoints for managing push notifications
- Implemented daily reminder and engagement reminder notification types with Expo push delivery

**Why**

- Enables the app to send push notifications to re-engage users and remind them about their goals
- Provides infrastructure for future notification channels (email, SMS placeholders included)

**How**

- Added three database migrations: `notifications`, `device_tokens`, and `notification_preferences` tables
- Added `Notification`, `DeviceToken`, and `NotificationPreference` models with validations, scopes, and helper methods
- Created `Notifications::BaseService` as foundation for notification types, with `DailyReminderService` and `EngagementReminderService` implementations
- Added `Notifications::Delivery::PushService` to send notifications via Expo push API, with error handling and device deactivation on `DeviceNotRegistered`
- Added `DeviceTokensController` with `create` and `destroy` endpoints for device registration
- Added rake task for testing notification delivery

**Testing**

- Added specs for all models (`Notification`, `DeviceToken`, `NotificationPreference`)
- Added specs for notification services (`DailyReminderService`, `EngagementReminderService`, `Delivery::PushService`)
- Added request specs for `DeviceTokensController`
- Added factories for `notification`, `notification_preference`, and `device_token`

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 172.23ms | ✅ |
| **90th Percentile Latency** | 158.57ms | - |
| **Average Latency** | 65.78ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 687 requests, 654 checks passed, 33 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 205.98ms | ✅ |
| **90th Percentile Latency** | 179.18ms | - |
| **Average Latency** | 76.78ms | - |
| **Failure Rate** | 6.128550074738415400% | ❌ |

**Summary:** 669 requests, 628 checks passed, 41 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 199.45ms | ✅ |
| **90th Percentile Latency** | 178.32ms | - |
| **Average Latency** | 73.51ms | - |
| **Failure Rate** | 7.14285714285714200% | ❌ |

**Summary:** 672 requests, 624 checks passed, 48 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 147.56ms | ✅ |
| **90th Percentile Latency** | 134.30ms | - |
| **Average Latency** | 56.43ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 705 requests, 470 checks passed, 235 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 199.68ms | ✅ |
| **90th Percentile Latency** | 184.47ms | - |
| **Average Latency** | 76.34ms | - |
| **Failure Rate** | 5.12820512820512800% | ❌ |

**Summary:** 663 requests, 629 checks passed, 34 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1781.25ms | ✅ |
| **90th Percentile Latency** | 1659.95ms | - |
| **Average Latency** | 756.38ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 306 requests, 204 checks passed, 102 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 164.98ms | ✅ |
| **90th Percentile Latency** | 150.63ms | - |
| **Average Latency** | 65.45ms | - |
| **Failure Rate** | 4.803493449781659500% | ❌ |

**Summary:** 687 requests, 654 checks passed, 33 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 195.07ms | ✅ |
| **90th Percentile Latency** | 177.51ms | - |
| **Average Latency** | 74.41ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 669 requests, 446 checks passed, 223 checks failed

---

<!-- PERF_RESULTS_END -->