### PR TITLE
feat/adds sidekiq cron to handle scheduling notifications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -96,6 +96,7 @@ RSpec/NestedGroups:
 RSpec/DescribeClass:
   Exclude:
     - 'spec/features/**/*'
+    - 'spec/integration/**/*'
     - 'spec/requests/**/*'
     - 'spec/system/**/*'
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem 'redis', '>= 4.0.1'
 
 # Background job processing
 gem 'sidekiq', '~> 7.0'
-gem 'sidekiq-status'
 gem 'sidekiq-cron', '~> 2.0'
+gem 'sidekiq-status'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'redis', '>= 4.0.1'
 # Background job processing
 gem 'sidekiq', '~> 7.0'
 gem 'sidekiq-status'
+gem 'sidekiq-cron', '~> 2.0'
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -133,6 +136,8 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     event_stream_parser (1.0.0)
     factory_bot (6.5.5)
       activesupport (>= 6.1.0)
@@ -149,6 +154,9 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -230,6 +238,7 @@ GEM
       stringio
     puma (7.1.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.18)
     rack-cors (3.0.0)
@@ -341,6 +350,11 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    sidekiq-cron (2.3.1)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
     sidekiq-status (4.0.0)
       base64
       chronic_duration
@@ -353,6 +367,7 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode (0.4.4.5)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
@@ -408,6 +423,7 @@ DEPENDENCIES
   ruby-openai (~> 6.0)
   shoulda-matchers
   sidekiq (~> 7.0)
+  sidekiq-cron (~> 2.0)
   sidekiq-status
   tzinfo-data
 

--- a/app/jobs/notifications/daily_reminder_job.rb
+++ b/app/jobs/notifications/daily_reminder_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Notifications::DailyReminderJob < ApplicationJob
+  queue_as :notifications
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform(profile_id)
+    profile = Profile.find(profile_id)
+    Notifications::DailyReminderService.new(profile).call
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.warn("DailyReminderJob: Profile not found: #{profile_id}")
+  end
+end

--- a/app/jobs/notifications/daily_reminder_job.rb
+++ b/app/jobs/notifications/daily_reminder_job.rb
@@ -8,7 +8,7 @@ class Notifications::DailyReminderJob < ApplicationJob
   def perform(profile_id)
     profile = Profile.find(profile_id)
     Notifications::DailyReminderService.new(profile).call
-  rescue ActiveRecord::RecordNotFound => e
+  rescue ActiveRecord::RecordNotFound
     Rails.logger.warn("DailyReminderJob: Profile not found: #{profile_id}")
   end
 end

--- a/app/jobs/notifications/engagement_reminder_job.rb
+++ b/app/jobs/notifications/engagement_reminder_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Notifications::EngagementReminderJob < ApplicationJob
+  queue_as :notifications
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform(profile_id)
+    profile = Profile.find(profile_id)
+    Notifications::EngagementReminderService.new(profile).call
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.warn("EngagementReminderJob: Profile not found: #{profile_id}")
+  end
+end

--- a/app/jobs/notifications/engagement_reminder_job.rb
+++ b/app/jobs/notifications/engagement_reminder_job.rb
@@ -8,7 +8,7 @@ class Notifications::EngagementReminderJob < ApplicationJob
   def perform(profile_id)
     profile = Profile.find(profile_id)
     Notifications::EngagementReminderService.new(profile).call
-  rescue ActiveRecord::RecordNotFound => e
+  rescue ActiveRecord::RecordNotFound
     Rails.logger.warn("EngagementReminderJob: Profile not found: #{profile_id}")
   end
 end

--- a/app/jobs/notifications/schedule_daily_reminders_job.rb
+++ b/app/jobs/notifications/schedule_daily_reminders_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Notifications::ScheduleDailyRemindersJob < ApplicationJob
+  queue_as :critical
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform
+    eligible_profiles.find_each do |profile|
+      next unless notification_time_matches?(profile)
+
+      Notifications::DailyReminderJob.perform_later(profile.id)
+    end
+  end
+
+  private
+
+  def eligible_profiles
+    Profile.push_notification_eligible
+  end
+
+  def notification_time_matches?(profile)
+    pref = profile.notification_preference
+    tz = ActiveSupport::TimeZone[pref.timezone]
+    local_hour = Time.current.in_time_zone(tz).hour
+
+    pref.preferred_time.hour == local_hour
+  end
+end

--- a/app/jobs/notifications/schedule_engagement_reminders_job.rb
+++ b/app/jobs/notifications/schedule_engagement_reminders_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Notifications::ScheduleEngagementRemindersJob < ApplicationJob
+  queue_as :critical
+
+  INACTIVE_DAYS_THRESHOLD = Notifications::EngagementReminderService::DAYS_THRESHOLD
+
+  def perform
+    eligible_profiles.find_each do |profile|
+      Notifications::EngagementReminderService.new(profile).call
+    end
+  end
+
+  private
+
+  def eligible_profiles
+    Profile.push_notification_eligible.inactive_for_days(INACTIVE_DAYS_THRESHOLD)
+  end
+end

--- a/app/models/notification_preference.rb
+++ b/app/models/notification_preference.rb
@@ -17,6 +17,17 @@ class NotificationPreference < ApplicationRecord
     sms_enabled
   end
 
+  # Check if a specific channel is enabled for a notification type
+  # Supports future granular per-type settings via channel_settings JSON column
+  def channel_enabled?(_notification_type, channel)
+    case channel.to_sym
+    when :push then push_enabled?
+    when :email then email_enabled?
+    when :sms then sms_enabled?
+    else false
+    end
+  end
+
   def in_quiet_hours?(time = Time.current)
     return false unless quiet_hours_start && quiet_hours_end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -83,6 +83,6 @@ class Profile < ApplicationRecord
   private
 
   def create_notification_preference
-    build_notification_preference.save!
+    build_notification_preference(timezone: 'UTC').save!
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Server
     # Enable sessions for Devise JWT authentication
     config.session_store :cookie_store, key: '_personal_coach_session'
     config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
 
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,22 +2,31 @@
 
 require 'sidekiq'
 require 'sidekiq-status'
+require 'sidekiq-cron'
 require 'openssl'
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: ENV['REDIS_URL'],
+    url: ENV.fetch('REDIS_URL', nil),
     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
 
   # Configure Sidekiq::Status server middleware
   # This enables job status tracking on the server side
   Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes.to_i
+
+  schedule_file = Rails.root.join('config', 'sidekiq_cron.yml')
+  if File.exist?(schedule_file)
+    Sidekiq::Cron::Job.load_from_hash(
+      YAML.load_file(schedule_file),
+      source: 'schedule'
+    )
+  end
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: ENV['REDIS_URL'],
+    url: ENV.fetch('REDIS_URL', nil),
     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sidekiq/web'
+require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get 'up' => 'rails/health#show', as: :rails_health_check
+  mount Sidekiq::Web => '/sidekiq'
 
   namespace :api do
     namespace :v1 do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,9 @@
 :concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 5) %>
 :queues:
-  - [default, 1]
+  - [critical, 3]        # Add: highest priority for schedulers
+  - [notifications, 2]   # Add: notification worker jobs
   - [ai_processing, 2]
+  - [default, 1]
   - [mailers, 1]
 
 :max_retries: 1
@@ -13,13 +15,17 @@
 development:
   :concurrency: 2
   :queues:
-    - [default, 1]
+    - [critical, 3]
+    - [notifications, 2]
     - [ai_processing, 2]
+    - [default, 1]
     - [mailers, 1]
 
 production:
   :concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 10) %>
   :queues:
+    - [critical, 3]
     - [ai_processing, 3]
+    - [notifications, 2]
     - [default, 2]
-    - [mailers, 1] 
+    - [mailers, 1]

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -1,0 +1,13 @@
+schedule_daily_reminders:
+  cron: "0 * * * *"
+  class: "Notifications::ScheduleDailyRemindersJob"
+  queue: critical
+  active_job: true
+  description: "Schedule daily reminder notifications based on user timezone preferences"
+
+schedule_engagement_reminders:
+  cron: "0 14 * * *"
+  class: "Notifications::ScheduleEngagementRemindersJob"
+  queue: critical
+  active_job: true
+  description: "Send engagement reminders to users inactive for 3+ days"

--- a/db/migrate/20251203044428_add_device_token_to_notifications.rb
+++ b/db/migrate/20251203044428_add_device_token_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddDeviceTokenToNotifications < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :notifications, :device_token, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_02_213916) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_03_044428) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,7 +77,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_02_213916) do
     t.text "error_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "device_token_id"
     t.index ["channel"], name: "index_notifications_on_channel"
+    t.index ["device_token_id"], name: "index_notifications_on_device_token_id"
     t.index ["notification_type"], name: "index_notifications_on_notification_type"
     t.index ["profile_id"], name: "index_notifications_on_profile_id"
     t.index ["scheduled_for"], name: "index_notifications_on_scheduled_for"
@@ -161,6 +163,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_02_213916) do
   add_foreign_key "ai_requests", "profiles"
   add_foreign_key "device_tokens", "profiles"
   add_foreign_key "notification_preferences", "profiles"
+  add_foreign_key "notifications", "device_tokens"
   add_foreign_key "notifications", "profiles"
   add_foreign_key "profiles", "users"
   add_foreign_key "smart_goals", "profiles"

--- a/lib/notifications/base_service.rb
+++ b/lib/notifications/base_service.rb
@@ -4,7 +4,7 @@ module Notifications
   class BaseService
     def initialize(profile, channels: nil)
       @profile = profile
-      @preference = profile.notification_perference
+      @preference = profile.notification_preference
       @channels = channels || default_channels
     end
 

--- a/lib/notifications/daily_reminder_service.rb
+++ b/lib/notifications/daily_reminder_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Notifications
-  class DailyReminderService
+  class DailyReminderService < BaseService
     def notification_type
       'daily_reminder'
     end

--- a/lib/notifications/engagement_reminder_service.rb
+++ b/lib/notifications/engagement_reminder_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Notifications
-  class EngagementReminderService
+  class EngagementReminderService < BaseService
     DAYS_THRESHOLD = 3
 
     def should_send?

--- a/spec/integration/notification_flow_spec.rb
+++ b/spec/integration/notification_flow_spec.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Notification flow integration' do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:profile) { user.profile }
+
+  before do
+    # Ensure notification preference exists and is properly configured
+    profile.notification_preference.update!(
+      push_enabled: true,
+      timezone: 'UTC',
+      preferred_time: Time.current.in_time_zone('UTC').beginning_of_hour
+    )
+
+    # Create an active device token
+    create(:device_token, profile: profile, platform: 'ios', active: true)
+
+    # Reload profile to ensure associations are fresh
+    profile.reload
+  end
+
+  describe 'Daily Reminder flow' do
+    describe 'ScheduleDailyRemindersJob -> DailyReminderJob -> DailyReminderService' do
+      context 'when profile is eligible and time matches' do
+        before { stub_expo_push_success }
+
+        it 'schedules and executes daily reminder through full flow' do
+          expect do
+            perform_enqueued_jobs do
+              Notifications::ScheduleDailyRemindersJob.perform_now
+            end
+          end.to change(Notification, :count).by(1)
+
+          notification = Notification.last
+          expect(notification).to have_attributes(
+            profile: profile,
+            notification_type: 'daily_reminder',
+            channel: 'push',
+            status: 'sent'
+          )
+          expect(notification.title).to start_with('Stay on Track!')
+          expect(notification.sent_at).to be_present
+        end
+
+        it 'calls the Expo push API via HttpClientService' do
+          mock_client = stub_expo_push_success
+
+          perform_enqueued_jobs do
+            Notifications::ScheduleDailyRemindersJob.perform_now
+          end
+
+          expect(mock_client).to have_received(:post).once
+        end
+      end
+
+      context 'when profile notification time does not match current hour' do
+        before do
+          profile.notification_preference.update!(preferred_time: 3.hours.from_now)
+        end
+
+        it 'does not enqueue DailyReminderJob' do
+          expect do
+            Notifications::ScheduleDailyRemindersJob.perform_now
+          end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+        end
+      end
+
+      context 'when push notifications are disabled' do
+        before do
+          profile.notification_preference.update!(push_enabled: false)
+        end
+
+        it 'does not enqueue DailyReminderJob' do
+          expect do
+            Notifications::ScheduleDailyRemindersJob.perform_now
+          end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+        end
+      end
+
+      context 'when device token is inactive' do
+        before do
+          profile.device_tokens.update_all(active: false)
+        end
+
+        it 'does not enqueue DailyReminderJob' do
+          expect do
+            Notifications::ScheduleDailyRemindersJob.perform_now
+          end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+        end
+      end
+    end
+
+    describe 'DailyReminderJob directly' do
+      before { stub_expo_push_success }
+
+      it 'sends notification to profile' do
+        expect do
+          Notifications::DailyReminderJob.perform_now(profile.id)
+        end.to change(Notification, :count).by(1)
+
+        expect(Notification.last.status).to eq('sent')
+      end
+
+      it 'handles missing profile gracefully' do
+        expect do
+          Notifications::DailyReminderJob.perform_now(-1)
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe 'Engagement Reminder flow' do
+    describe 'ScheduleEngagementRemindersJob -> EngagementReminderService' do
+      context 'when profile has been inactive for threshold days' do
+        before do
+          stub_expo_push_success
+          profile.notification_preference.update!(last_opened_app_at: 5.days.ago)
+        end
+
+        it 'sends engagement reminder' do
+          expect do
+            Notifications::ScheduleEngagementRemindersJob.perform_now
+          end.to change(Notification, :count).by(1)
+
+          notification = Notification.last
+          expect(notification).to have_attributes(
+            profile: profile,
+            notification_type: 'engagement_reminder',
+            channel: 'push',
+            status: 'sent'
+          )
+        end
+      end
+
+      context 'when profile has been active recently' do
+        before do
+          profile.notification_preference.update!(last_opened_app_at: 1.day.ago)
+        end
+
+        it 'does not send engagement reminder' do
+          expect do
+            Notifications::ScheduleEngagementRemindersJob.perform_now
+          end.not_to change(Notification, :count)
+        end
+      end
+
+      context 'when profile has never opened the app' do
+        before do
+          stub_expo_push_success
+          profile.notification_preference.update!(last_opened_app_at: nil)
+        end
+
+        it 'sends engagement reminder' do
+          expect do
+            Notifications::ScheduleEngagementRemindersJob.perform_now
+          end.to change(Notification, :count).by(1)
+        end
+      end
+    end
+  end
+
+  describe 'Multi-device support' do
+    before do
+      stub_expo_push_success
+      # Add a second device
+      create(:device_token, profile: profile, platform: 'android', active: true)
+      profile.reload
+    end
+
+    it 'sends notification to all active devices' do
+      expect do
+        Notifications::DailyReminderJob.perform_now(profile.id)
+      end.to change(Notification, :count).by(2)
+
+      notifications = Notification.last(2)
+      expect(notifications.map { |n| n.device_token.platform }).to contain_exactly('ios', 'android')
+    end
+  end
+
+  describe 'Error handling' do
+    context 'when Expo returns DeviceNotRegistered error' do
+      before { stub_expo_push_device_not_registered }
+
+      it 'deactivates the device token' do
+        device_token = profile.device_tokens.active.first
+
+        expect do
+          Notifications::DailyReminderJob.perform_now(profile.id)
+        end.to change { device_token.reload.active }.from(true).to(false)
+      end
+
+      it 'still marks notification as sent (Expo returned 200)' do
+        Notifications::DailyReminderJob.perform_now(profile.id)
+
+        expect(Notification.last.status).to eq('sent')
+      end
+    end
+
+    context 'when Expo API returns HTTP error' do
+      before { stub_expo_push_http_failure }
+
+      it 'marks notification as failed' do
+        Notifications::DailyReminderJob.perform_now(profile.id)
+
+        notification = Notification.last
+        expect(notification.status).to eq('failed')
+        expect(notification.error_message).to be_present
+      end
+    end
+  end
+
+  describe 'Quiet hours' do
+    before do
+      stub_expo_push_success
+      current_hour = Time.current.in_time_zone('UTC').hour
+      profile.notification_preference.update!(
+        quiet_hours_start: Time.zone.parse("#{current_hour}:00"),
+        quiet_hours_end: Time.zone.parse("#{(current_hour + 2) % 24}:00")
+      )
+    end
+
+    it 'does not send notifications during quiet hours' do
+      expect do
+        Notifications::DailyReminderService.new(profile).call
+      end.not_to change(Notification, :count)
+    end
+  end
+end

--- a/spec/integration/notification_flow_spec.rb
+++ b/spec/integration/notification_flow_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'Notification flow integration' do
 
       context 'when device token is inactive' do
         before do
-          profile.device_tokens.update_all(active: false)
+          profile.device_tokens.each { |device_token| device_token.update!(active: false) }
         end
 
         it 'does not enqueue DailyReminderJob' do

--- a/spec/jobs/notifications/daily_reminder_job_spec.rb
+++ b/spec/jobs/notifications/daily_reminder_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::DailyReminderJob, type: :job do
+  let(:profile) { create(:profile) }
+
+  before do
+    Sidekiq::Testing.inline!
+    allow(Rails.logger).to receive(:warn)
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  describe '#perform' do
+    context 'when profile exists' do
+      it 'calls DailyReminderService with the profile' do
+        mock_service = instance_double(Notifications::DailyReminderService)
+        allow(Notifications::DailyReminderService).to receive(:new)
+          .with(profile)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now(profile.id)
+
+        expect(Notifications::DailyReminderService).to have_received(:new).with(profile)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'when profile is not found' do
+      it 'logs a warning and does not raise an error' do
+        expect do
+          described_class.perform_now(999_999)
+        end.not_to raise_error
+
+        expect(Rails.logger).to have_received(:warn)
+          .with(/DailyReminderJob: Profile not found: 999999/)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the notifications queue' do
+      expect(described_class.queue_name).to eq('notifications')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/engagement_reminder_job_spec.rb
+++ b/spec/jobs/notifications/engagement_reminder_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::EngagementReminderJob, type: :job do
+  let(:profile) { create(:profile) }
+
+  before do
+    Sidekiq::Testing.inline!
+    allow(Rails.logger).to receive(:warn)
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  describe '#perform' do
+    context 'when profile exists' do
+      it 'calls EngagementReminderService with the profile' do
+        mock_service = instance_double(Notifications::EngagementReminderService)
+        allow(Notifications::EngagementReminderService).to receive(:new)
+          .with(profile)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now(profile.id)
+
+        expect(Notifications::EngagementReminderService).to have_received(:new).with(profile)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'when profile is not found' do
+      it 'logs a warning and does not raise an error' do
+        expect do
+          described_class.perform_now(999_999)
+        end.not_to raise_error
+
+        expect(Rails.logger).to have_received(:warn)
+          .with(/EngagementReminderJob: Profile not found: 999999/)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the notifications queue' do
+      expect(described_class.queue_name).to eq('notifications')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/notifications/schedule_daily_reminders_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
+  before do
+    Sidekiq::Testing.fake!
+    Sidekiq::Queues.clear_all
+  end
+
+  describe '#perform' do
+    context 'when profile is eligible and time matches' do
+      it 'enqueues DailyReminderJob for the profile' do
+        current_hour = Time.current.in_time_zone('UTC').hour
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{current_hour}:00")
+        )
+        create(:device_token, profile: profile, active: true)
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(Notifications::DailyReminderJob).with(profile.id)
+      end
+    end
+
+    context 'when preferred time does not match current hour' do
+      it 'does not enqueue DailyReminderJob' do
+        current_hour = Time.current.in_time_zone('UTC').hour
+        different_hour = (current_hour + 2) % 24
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{different_hour}:00")
+        )
+        create(:device_token, profile: profile, active: true)
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+      end
+    end
+
+    context 'when profile does not have push enabled' do
+      it 'does not enqueue DailyReminderJob' do
+        current_hour = Time.current.in_time_zone('UTC').hour
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: false,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{current_hour}:00")
+        )
+        create(:device_token, profile: profile, active: true)
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+      end
+    end
+
+    context 'when profile does not have active device tokens' do
+      it 'does not enqueue DailyReminderJob' do
+        current_hour = Time.current.in_time_zone('UTC').hour
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{current_hour}:00")
+        )
+        create(:device_token, profile: profile, active: false)
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::DailyReminderJob)
+      end
+    end
+
+    context 'with multiple eligible profiles' do
+      it 'enqueues jobs for all matching profiles' do
+        current_hour = Time.current.in_time_zone('UTC').hour
+
+        profile1 = create(:profile)
+        profile1.notification_preference.update!(
+          push_enabled: true,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{current_hour}:00")
+        )
+        create(:device_token, profile: profile1, active: true)
+
+        profile2 = create(:profile)
+        profile2.notification_preference.update!(
+          push_enabled: true,
+          timezone: 'UTC',
+          preferred_time: Time.zone.parse("#{current_hour}:00")
+        )
+        create(:device_token, profile: profile2, active: true)
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(Notifications::DailyReminderJob).exactly(2).times
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the critical queue' do
+      expect(described_class.queue_name).to eq('critical')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/schedule_engagement_reminders_job_spec.rb
+++ b/spec/jobs/notifications/schedule_engagement_reminders_job_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::ScheduleEngagementRemindersJob, type: :job do
+  before do
+    Sidekiq::Testing.inline!
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  describe '#perform' do
+    context 'when profile is eligible and inactive for 3+ days' do
+      it 'calls EngagementReminderService for the profile' do
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: 4.days.ago
+        )
+        create(:device_token, profile: profile, active: true)
+
+        mock_service = instance_double(Notifications::EngagementReminderService)
+        allow(Notifications::EngagementReminderService).to receive(:new)
+          .with(profile)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now
+
+        expect(Notifications::EngagementReminderService).to have_received(:new).with(profile)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'when profile has been active within 3 days' do
+      it 'does not call EngagementReminderService' do
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: 1.day.ago
+        )
+        create(:device_token, profile: profile, active: true)
+
+        expect(Notifications::EngagementReminderService).not_to receive(:new)
+
+        described_class.perform_now
+      end
+    end
+
+    context 'when profile does not have push enabled' do
+      it 'does not call EngagementReminderService' do
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: false,
+          last_opened_app_at: 4.days.ago
+        )
+        create(:device_token, profile: profile, active: true)
+
+        expect(Notifications::EngagementReminderService).not_to receive(:new)
+
+        described_class.perform_now
+      end
+    end
+
+    context 'when profile does not have active device tokens' do
+      it 'does not call EngagementReminderService' do
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: 4.days.ago
+        )
+        create(:device_token, profile: profile, active: false)
+
+        expect(Notifications::EngagementReminderService).not_to receive(:new)
+
+        described_class.perform_now
+      end
+    end
+
+    context 'when profile has never opened the app' do
+      it 'calls EngagementReminderService (nil last_opened_app_at)' do
+        profile = create(:profile)
+        profile.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: nil
+        )
+        create(:device_token, profile: profile, active: true)
+
+        mock_service = instance_double(Notifications::EngagementReminderService)
+        allow(Notifications::EngagementReminderService).to receive(:new)
+          .with(profile)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now
+
+        expect(Notifications::EngagementReminderService).to have_received(:new).with(profile)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'with multiple eligible profiles' do
+      it 'calls EngagementReminderService for all matching profiles' do
+        profile1 = create(:profile)
+        profile1.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: 5.days.ago
+        )
+        create(:device_token, profile: profile1, active: true)
+
+        profile2 = create(:profile)
+        profile2.notification_preference.update!(
+          push_enabled: true,
+          last_opened_app_at: 10.days.ago
+        )
+        create(:device_token, profile: profile2, active: true)
+
+        mock_service1 = instance_double(Notifications::EngagementReminderService)
+        mock_service2 = instance_double(Notifications::EngagementReminderService)
+
+        allow(Notifications::EngagementReminderService).to receive(:new)
+          .with(profile1)
+          .and_return(mock_service1)
+        allow(Notifications::EngagementReminderService).to receive(:new)
+          .with(profile2)
+          .and_return(mock_service2)
+        allow(mock_service1).to receive(:call)
+        allow(mock_service2).to receive(:call)
+
+        described_class.perform_now
+
+        expect(mock_service1).to have_received(:call)
+        expect(mock_service2).to have_received(:call)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the critical queue' do
+      expect(described_class.queue_name).to eq('critical')
+    end
+  end
+
+  describe 'constants' do
+    it 'defines INACTIVE_DAYS_THRESHOLD from service' do
+      expect(described_class::INACTIVE_DAYS_THRESHOLD).to eq(3)
+    end
+  end
+end

--- a/spec/lib/notifications/daily_reminder_service_spec.rb
+++ b/spec/lib/notifications/daily_reminder_service_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::DailyReminderService do
-  let(:profile) { create(:profile) }
-
   subject(:service) { described_class.new(profile) }
+
+  let(:profile) { create(:profile) }
 
   describe '#notification_type' do
     it 'returns daily_reminder' do

--- a/spec/lib/notifications/daily_reminder_service_spec.rb
+++ b/spec/lib/notifications/daily_reminder_service_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::DailyReminderService do
-  subject(:service) { described_class.new }
+  let(:profile) { create(:profile) }
+
+  subject(:service) { described_class.new(profile) }
 
   describe '#notification_type' do
     it 'returns daily_reminder' do

--- a/spec/lib/notifications/engagement_reminder_service_spec.rb
+++ b/spec/lib/notifications/engagement_reminder_service_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::EngagementReminderService do
-  let(:profile) { create(:profile) }
-
   subject(:service) { described_class.new(profile) }
+
+  let(:profile) { create(:profile) }
 
   describe '#notification_type' do
     it 'returns engagement_reminder' do

--- a/spec/lib/notifications/engagement_reminder_service_spec.rb
+++ b/spec/lib/notifications/engagement_reminder_service_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Notifications::EngagementReminderService do
-  subject(:service) { described_class.new }
+  let(:profile) { create(:profile) }
+
+  subject(:service) { described_class.new(profile) }
 
   describe '#notification_type' do
     it 'returns engagement_reminder' do
@@ -27,11 +29,8 @@ RSpec.describe Notifications::EngagementReminderService do
   end
 
   describe '#notification_body' do
-    let(:profile) { create(:profile) }
-
     before do
       profile.notification_preference.update!(last_opened_app_at: 5.days.ago)
-      service.instance_variable_set(:@profile, profile)
     end
 
     it 'includes days since last open' do
@@ -46,12 +45,6 @@ RSpec.describe Notifications::EngagementReminderService do
   end
 
   describe '#days_since_last_open' do
-    let(:profile) { create(:profile) }
-
-    before do
-      service.instance_variable_set(:@profile, profile)
-    end
-
     context 'when user has opened the app recently' do
       before { profile.notification_preference.update!(last_opened_app_at: 2.days.ago) }
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Profile, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_many(:smart_goals).dependent(:destroy) }
+    it { is_expected.to have_many(:tasks).dependent(:destroy) }
+    it { is_expected.to have_many(:ai_requests).dependent(:destroy) }
+    it { is_expected.to have_many(:tickets).dependent(:destroy) }
+    it { is_expected.to have_many(:notifications).dependent(:destroy) }
+    it { is_expected.to have_many(:device_tokens).dependent(:destroy) }
+    it { is_expected.to have_one(:notification_preference).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_inclusion_of(:onboarding_status).in_array(%w[incomplete complete]) }
+  end
+
+  describe 'callbacks' do
+    it 'creates notification_preference after create' do
+      profile = create(:profile)
+      expect(profile.notification_preference).to be_present
+    end
+  end
+
+  describe 'scopes' do
+    describe '.push_notification_eligible' do
+      it 'returns profiles with push enabled and active devices' do
+        eligible_profile = create(:profile)
+        eligible_profile.notification_preference.update!(push_enabled: true)
+        create(:device_token, profile: eligible_profile, active: true)
+
+        ineligible_profile = create(:profile)
+        ineligible_profile.notification_preference.update!(push_enabled: false)
+
+        expect(described_class.push_notification_eligible).to contain_exactly(eligible_profile)
+      end
+    end
+
+    describe '.inactive_for_days' do
+      it 'returns profiles inactive for specified days or with nil last_opened_app_at' do
+        inactive_profile = create(:profile)
+        inactive_profile.notification_preference.update!(last_opened_app_at: 5.days.ago)
+
+        active_profile = create(:profile)
+        active_profile.notification_preference.update!(last_opened_app_at: 1.day.ago)
+
+        never_opened_profile = create(:profile)
+        never_opened_profile.notification_preference.update!(last_opened_app_at: nil)
+
+        test_profiles = [inactive_profile, active_profile, never_opened_profile]
+        result = described_class.where(id: test_profiles.map(&:id)).inactive_for_days(3)
+        expect(result).to contain_exactly(inactive_profile, never_opened_profile)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    let(:profile) { create(:profile, first_name: 'John', last_name: 'Doe') }
+
+    describe '#onboarding_complete?' do
+      it 'returns true when onboarding_status is complete' do
+        profile.update!(onboarding_status: 'complete')
+        expect(profile.onboarding_complete?).to be true
+      end
+
+      it 'returns false when onboarding_status is incomplete' do
+        expect(profile.onboarding_complete?).to be false
+      end
+    end
+
+    describe '#complete_onboarding!' do
+      it 'updates status and sets completed_at timestamp' do
+        profile.complete_onboarding!
+        expect(profile.onboarding_status).to eq('complete')
+        expect(profile.onboarding_completed_at).to be_within(1.second).of(Time.current)
+      end
+    end
+
+    describe '#incomplete_tasks' do
+      it 'returns only incomplete tasks' do
+        incomplete = create(:task, profile: profile, completed: false)
+        create(:task, profile: profile, completed: true)
+
+        expect(profile.incomplete_tasks).to contain_exactly(incomplete)
+      end
+    end
+
+    describe '#push_notifications_enabled?' do
+      it 'returns true when push is enabled and push tokens exist' do
+        profile.notification_preference.update!(push_enabled: true)
+        create(:device_token, profile: profile, active: true, platform: 'ios')
+
+        expect(profile.push_notifications_enabled?).to be true
+      end
+
+      it 'returns false when no active push tokens' do
+        profile.notification_preference.update!(push_enabled: true)
+        create(:device_token, profile: profile, active: false, platform: 'ios')
+
+        expect(profile.push_notifications_enabled?).to be false
+      end
+    end
+
+    describe '#record_app_open!' do
+      it 'updates last_opened_app_at on notification_preference' do
+        profile.record_app_open!
+        expect(profile.notification_preference.last_opened_app_at).to be_within(1.second).of(Time.current)
+      end
+    end
+  end
+end

--- a/spec/support/expo_push_helpers.rb
+++ b/spec/support/expo_push_helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ExpoPushHelpers
+  def stub_expo_push_success
+    mock_response = instance_double(Faraday::Response,
+                                    success?: true,
+                                    body: { 'data' => { 'status' => 'ok', 'id' => 'receipt-123' } })
+    mock_client_instance = instance_double(HttpClientService, post: mock_response)
+    allow(HttpClientService).to receive(:new).and_return(mock_client_instance)
+    mock_client_instance
+  end
+
+  def stub_expo_push_device_not_registered
+    mock_response = instance_double(Faraday::Response,
+                                    success?: true,
+                                    body: {
+                                      'data' => {
+                                        'status' => 'error',
+                                        'message' => 'DeviceNotRegistered',
+                                        'details' => { 'error' => 'DeviceNotRegistered' }
+                                      }
+                                    })
+    mock_client_instance = instance_double(HttpClientService, post: mock_response)
+    allow(HttpClientService).to receive(:new).and_return(mock_client_instance)
+    mock_client_instance
+  end
+
+  def stub_expo_push_http_failure(error_body = 'Internal Server Error')
+    mock_response = instance_double(Faraday::Response,
+                                    success?: false,
+                                    body: error_body)
+    mock_client_instance = instance_double(HttpClientService, post: mock_response)
+    allow(HttpClientService).to receive(:new).and_return(mock_client_instance)
+    mock_client_instance
+  end
+end
+
+RSpec.configure do |config|
+  config.include ExpoPushHelpers
+end


### PR DESCRIPTION
**Summary**

- Added sidekiq-cron to schedule and deliver daily reminder and engagement reminder notifications.
- Introduced background jobs that respect user timezone preferences and notification channel settings.

**Why**

- Users need automated push notifications for daily reminders (at their preferred time) and re-engagement reminders (after 3+ days of inactivity).
- Scheduling must be timezone-aware and respect per-user notification preferences.

**How**

- Added `sidekiq-cron` dependency and configured the cron schedule with two recurring jobs: `ScheduleDailyRemindersJob` (hourly) and `ScheduleEngagementRemindersJob` (daily at 14:00 UTC).
- Created scheduler jobs that find eligible profiles using new scopes (`push_notification_eligible`, `inactive_for_days`) and dispatch individual notification jobs.
- Added `DailyReminderJob` and `EngagementReminderJob` to handle per-profile notification delivery.
- Added scopes to `Profile` model for finding profiles with push enabled and active device tokens.
- Added `device_token` foreign key to notifications table for tracking which token was used.
- Configured queue priorities (`critical` for schedulers) and integrated cron UI into Sidekiq dashboard.

**Testing**

- Added unit tests for all four notification jobs (`DailyReminderJob`, `EngagementReminderJob`, `ScheduleDailyRemindersJob`, `ScheduleEngagementRemindersJob`).
- Added end-to-end tests for notification flows.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 200.49ms | ✅ |
| **90th Percentile Latency** | 182.41ms | - |
| **Average Latency** | 79.33ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 669 requests, 669 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 207.63ms | ✅ |
| **90th Percentile Latency** | 198.36ms | - |
| **Average Latency** | 81.18ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 669 requests, 669 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 209.30ms | ✅ |
| **90th Percentile Latency** | 200.34ms | - |
| **Average Latency** | 85.08ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 654 requests, 654 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 186.88ms | ✅ |
| **90th Percentile Latency** | 163.71ms | - |
| **Average Latency** | 65.12ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 690 requests, 460 checks passed, 230 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 211.69ms | ✅ |
| **90th Percentile Latency** | 200.03ms | - |
| **Average Latency** | 81.80ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 669 requests, 669 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1846.57ms | ✅ |
| **90th Percentile Latency** | 1683.04ms | - |
| **Average Latency** | 785.56ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 188.76ms | ✅ |
| **90th Percentile Latency** | 176.30ms | - |
| **Average Latency** | 71.81ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 678 requests, 678 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 230.22ms | ✅ |
| **90th Percentile Latency** | 216.30ms | - |
| **Average Latency** | 89.29ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 654 requests, 436 checks passed, 218 checks failed

---

<!-- PERF_RESULTS_END -->