### PR TITLE
feat/adds route to handle notification preferences

### DIFF
--- a/app/controllers/api/v1/notification_preferences_controller.rb
+++ b/app/controllers/api/v1/notification_preferences_controller.rb
@@ -28,13 +28,13 @@ module Api
       def notification_preference_response
         {
           notification_preference: current_notification_preference.as_json(
-            only: %i[push_enabled preferred_time timezone]
+            only: %i[push_enabled preferred_time]
           )
         }
       end
 
       def notification_preference_params
-        params.require(:notification_preference).permit(:push_enabled, :preferred_time, :timezone)
+        params.require(:notification_preference).permit(:push_enabled, :preferred_time)
       end
     end
   end

--- a/app/controllers/api/v1/notification_preferences_controller.rb
+++ b/app/controllers/api/v1/notification_preferences_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class NotificationPreferencesController < ApplicationController
+      before_action :authenticate_api_v1_user!
+
+      def show
+        render json: notification_preference_response
+      end
+
+      def update
+        if current_notification_preference.update(notification_preference_params)
+          render json: notification_preference_response
+        else
+          render json: {
+            errors: current_notification_preference.errors.full_messages
+          }, status: :unprocessable_content
+        end
+      end
+
+      private
+
+      def current_notification_preference
+        current_api_v1_profile.notification_preference
+      end
+
+      def notification_preference_response
+        {
+          notification_preference: current_notification_preference.as_json(
+            only: %i[push_enabled preferred_time timezone]
+          )
+        }
+      end
+
+      def notification_preference_params
+        params.require(:notification_preference).permit(:push_enabled, :preferred_time, :timezone)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -39,7 +39,7 @@ module Api
       def profile_params
         params.require(:profile).permit(
           :first_name, :last_name, :work_role, :education,
-          :desires, :limiting_beliefs, :onboarding_status
+          :desires, :limiting_beliefs, :onboarding_status, :timezone
         )
       end
     end

--- a/app/jobs/notifications/schedule_daily_reminders_job.rb
+++ b/app/jobs/notifications/schedule_daily_reminders_job.rb
@@ -21,7 +21,7 @@ class Notifications::ScheduleDailyRemindersJob < ApplicationJob
 
   def notification_time_matches?(profile)
     pref = profile.notification_preference
-    tz = ActiveSupport::TimeZone[pref.timezone]
+    tz = ActiveSupport::TimeZone[profile.timezone]
     local_hour = Time.current.in_time_zone(tz).hour
 
     pref.preferred_time.hour == local_hour

--- a/app/models/notification_preference.rb
+++ b/app/models/notification_preference.rb
@@ -3,8 +3,6 @@
 class NotificationPreference < ApplicationRecord
   belongs_to :profile
 
-  validates :timezone, presence: true
-
   def push_enabled?
     push_enabled
   end
@@ -31,7 +29,7 @@ class NotificationPreference < ApplicationRecord
   def in_quiet_hours?(time = Time.current)
     return false unless quiet_hours_start && quiet_hours_end
 
-    current_time = time.in_time_zone(timezone).strftime('%H:%M')
+    current_time = time.in_time_zone(profile.timezone).strftime('%H:%M')
     start_time = quiet_hours_start.strftime('%H:%M')
     end_time = quiet_hours_end.strftime('%H:%M')
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -30,11 +30,17 @@ class Profile < ApplicationRecord
   }
 
   validates :onboarding_status, inclusion: { in: %w[incomplete complete] }
+  validates :timezone, inclusion: {
+    in: %w[Pacific/Honolulu America/Anchorage America/Los_Angeles America/Denver America/Chicago America/New_York
+           America/Halifax America/Sao_Paulo Atlantic/Reykjavik Europe/London Europe/Paris Europe/Berlin Europe/Moscow
+           Asia/Dubai Asia/Kolkata Asia/Bangkok Asia/Singapore Asia/Hong_Kong Asia/Tokyo Australia/Sydney
+           Pacific/Auckland UTC]
+  }
 
   after_create :create_notification_preference
 
   delegate :push_enabled?, :email_enabled?, :sms_enabled?,
-           :timezone, :preferred_time, :in_quiet_hours?,
+           :preferred_time, :in_quiet_hours?,
            :last_opened_app_at, to: :notification_preference, allow_nil: true
 
   def incomplete_tasks
@@ -83,6 +89,6 @@ class Profile < ApplicationRecord
   private
 
   def create_notification_preference
-    build_notification_preference(timezone: 'UTC').save!
+    build_notification_preference.save!
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       # Job status endpoint
       get 'jobs/:id', to: 'job_status#show'
       resources :device_tokens, only: %i[create destroy]
+      resource :notification_preferences, only: %i[show update]
     end
   end
 end

--- a/db/migrate/20251211194943_move_timezone_from_notification_preferences_to_profiles.rb
+++ b/db/migrate/20251211194943_move_timezone_from_notification_preferences_to_profiles.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class MoveTimezoneFromNotificationPreferencesToProfiles < ActiveRecord::Migration[7.2]
+  def up
+    # Add timezone column to profiles
+    add_column :profiles, :timezone, :string, default: 'UTC'
+
+    # Copy timezone values from notification_preferences to profiles
+    execute <<-SQL.squish
+      UPDATE profiles
+      SET timezone = notification_preferences.timezone
+      FROM notification_preferences
+      WHERE profiles.id = notification_preferences.profile_id
+    SQL
+
+    # Remove timezone column from notification_preferences
+    remove_column :notification_preferences, :timezone
+  end
+
+  def down
+    # Add timezone column back to notification_preferences
+    add_column :notification_preferences, :timezone, :string, default: 'UTC'
+
+    # Copy timezone values back from profiles to notification_preferences
+    execute <<-SQL.squish
+      UPDATE notification_preferences
+      SET timezone = profiles.timezone
+      FROM profiles
+      WHERE notification_preferences.profile_id = profiles.id
+    SQL
+
+    # Remove timezone column from profiles
+    remove_column :profiles, :timezone
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_03_044428) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_11_194943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,7 +54,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_03_044428) do
     t.boolean "email_enabled", default: true, null: false
     t.boolean "sms_enabled", default: false, null: false
     t.time "preferred_time", default: "2000-01-01 09:00:00"
-    t.string "timezone", default: "UTC"
     t.time "quiet_hours_start"
     t.time "quiet_hours_end"
     t.jsonb "channel_settings"
@@ -98,6 +97,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_03_044428) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "timezone", default: "UTC"
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/spec/factories/notification_preferences.rb
+++ b/spec/factories/notification_preferences.rb
@@ -7,6 +7,5 @@ FactoryBot.define do
     email_enabled { true }
     sms_enabled { false }
     preferred_time { '09:00' }
-    timezone { 'UTC' }
   end
 end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     education { Faker::Educator.degree }
     desires { Faker::Lorem.paragraph(sentence_count: 2) }
     limiting_beliefs { Faker::Lorem.paragraph(sentence_count: 1) }
+    timezone { 'UTC' }
     onboarding_status { 'incomplete' }
 
     trait :completed_onboarding do

--- a/spec/integration/notification_flow_spec.rb
+++ b/spec/integration/notification_flow_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe 'Notification flow integration' do
   let(:profile) { user.profile }
 
   before do
-    # Ensure notification preference exists and is properly configured
+    # Ensure profile has timezone set and notification preference is properly configured
+    profile.update!(timezone: 'UTC')
     profile.notification_preference.update!(
       push_enabled: true,
-      timezone: 'UTC',
       preferred_time: Time.current.in_time_zone('UTC').beginning_of_hour
     )
 

--- a/spec/jobs/notifications/schedule_daily_reminders_job_spec.rb
+++ b/spec/jobs/notifications/schedule_daily_reminders_job_spec.rb
@@ -13,10 +13,9 @@ RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
     context 'when profile is eligible and time matches' do
       it 'enqueues DailyReminderJob for the profile' do
         current_hour = Time.current.in_time_zone('UTC').hour
-        profile = create(:profile)
+        profile = create(:profile, timezone: 'UTC')
         profile.notification_preference.update!(
           push_enabled: true,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{current_hour}:00")
         )
         create(:device_token, profile: profile, active: true)
@@ -31,10 +30,9 @@ RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
       it 'does not enqueue DailyReminderJob' do
         current_hour = Time.current.in_time_zone('UTC').hour
         different_hour = (current_hour + 2) % 24
-        profile = create(:profile)
+        profile = create(:profile, timezone: 'UTC')
         profile.notification_preference.update!(
           push_enabled: true,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{different_hour}:00")
         )
         create(:device_token, profile: profile, active: true)
@@ -48,10 +46,9 @@ RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
     context 'when profile does not have push enabled' do
       it 'does not enqueue DailyReminderJob' do
         current_hour = Time.current.in_time_zone('UTC').hour
-        profile = create(:profile)
+        profile = create(:profile, timezone: 'UTC')
         profile.notification_preference.update!(
           push_enabled: false,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{current_hour}:00")
         )
         create(:device_token, profile: profile, active: true)
@@ -65,10 +62,9 @@ RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
     context 'when profile does not have active device tokens' do
       it 'does not enqueue DailyReminderJob' do
         current_hour = Time.current.in_time_zone('UTC').hour
-        profile = create(:profile)
+        profile = create(:profile, timezone: 'UTC')
         profile.notification_preference.update!(
           push_enabled: true,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{current_hour}:00")
         )
         create(:device_token, profile: profile, active: false)
@@ -83,18 +79,16 @@ RSpec.describe Notifications::ScheduleDailyRemindersJob, type: :job do
       it 'enqueues jobs for all matching profiles' do
         current_hour = Time.current.in_time_zone('UTC').hour
 
-        profile1 = create(:profile)
+        profile1 = create(:profile, timezone: 'UTC')
         profile1.notification_preference.update!(
           push_enabled: true,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{current_hour}:00")
         )
         create(:device_token, profile: profile1, active: true)
 
-        profile2 = create(:profile)
+        profile2 = create(:profile, timezone: 'UTC')
         profile2.notification_preference.update!(
           push_enabled: true,
-          timezone: 'UTC',
           preferred_time: Time.zone.parse("#{current_hour}:00")
         )
         create(:device_token, profile: profile2, active: true)

--- a/spec/models/notification_preference_spec.rb
+++ b/spec/models/notification_preference_spec.rb
@@ -7,12 +7,9 @@ RSpec.describe NotificationPreference, type: :model do
     it { is_expected.to belong_to(:profile) }
   end
 
-  describe 'validations' do
-    it { is_expected.to validate_presence_of(:timezone) }
-  end
-
   describe '#in_quiet_hours?' do
-    let(:preference) { build(:notification_preference, timezone: 'UTC') }
+    let(:profile) { create(:profile, timezone: 'UTC') }
+    let(:preference) { profile.notification_preference }
 
     context 'when quiet hours are not set' do
       it 'returns false' do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe Profile, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_inclusion_of(:onboarding_status).in_array(%w[incomplete complete]) }
+
+    it 'validates timezone inclusion' do
+      expect(subject).to validate_inclusion_of(:timezone).in_array(
+        %w[Pacific/Honolulu America/Anchorage America/Los_Angeles America/Denver America/Chicago America/New_York
+           America/Halifax America/Sao_Paulo Atlantic/Reykjavik Europe/London Europe/Paris Europe/Berlin Europe/Moscow
+           Asia/Dubai Asia/Kolkata Asia/Bangkok Asia/Singapore Asia/Hong_Kong Asia/Tokyo Australia/Sydney
+           Pacific/Auckland UTC]
+      )
+    end
   end
 
   describe 'callbacks' do


### PR DESCRIPTION
**Summary**

- Added API endpoints to manage user notification preferences
- Moved `timezone` property from NotificationPreference to Profile model

**Why**

- Clients need endpoints to read and update notification preferences (push_enabled, preferred_time)
- Timezone is a profile-level concern, not specific to notification settings

**How**

- Added `NotificationPreferencesController` with `show` and `update` actions (exposes `push_enabled` and `preferred_time`)
- Created migration to add `timezone` column to `profiles` table
- Refactored to remove `timezone` from NotificationPreference, now stored on Profile with validation for supported timezones
- Updated schema to reflect the migration

**Testing**

- Updated tests for timezone property relocation

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 198.77ms | ✅ |
| **90th Percentile Latency** | 174.05ms | - |
| **Average Latency** | 74.13ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 675 requests, 675 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 197.08ms | ✅ |
| **90th Percentile Latency** | 190.68ms | - |
| **Average Latency** | 73.41ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 675 requests, 675 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 292.24ms | ✅ |
| **90th Percentile Latency** | 226.03ms | - |
| **Average Latency** | 98.47ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 618 requests, 618 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 164.32ms | ✅ |
| **90th Percentile Latency** | 144.71ms | - |
| **Average Latency** | 60.93ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 699 requests, 466 checks passed, 233 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 200.09ms | ✅ |
| **90th Percentile Latency** | 194.43ms | - |
| **Average Latency** | 80.85ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 666 requests, 666 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1642.03ms | ✅ |
| **90th Percentile Latency** | 1464.28ms | - |
| **Average Latency** | 709.69ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 303 requests, 202 checks passed, 101 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 176.70ms | ✅ |
| **90th Percentile Latency** | 165.33ms | - |
| **Average Latency** | 66.75ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 684 requests, 684 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 200.27ms | ✅ |
| **90th Percentile Latency** | 197.26ms | - |
| **Average Latency** | 72.71ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 678 requests, 452 checks passed, 226 checks failed

---

<!-- PERF_RESULTS_END -->