### PR TITLE
feat: implement password reset flow (PC-A2 backend)

### DIFF
--- a/app/controllers/api/v1/passwords_controller.rb
+++ b/app/controllers/api/v1/passwords_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative '../../concerns/rack_session_fix_controller'
+
+module Api
+  module V1
+    class PasswordsController < Devise::PasswordsController
+      include ::RackSessionFixController
+
+      respond_to :json
+
+      # POST /api/v1/password
+      # Sends reset instructions. Always returns 200 to avoid leaking which
+      # emails are registered.
+      def create
+        email = params.dig(:user, :email).to_s.strip.downcase
+        User.send_reset_password_instructions(email: email) if email.present?
+
+        render json: {
+          status: { code: 200, message: 'If that email is registered, password reset instructions have been sent.' }
+        }, status: :ok
+      end
+
+      # PUT /api/v1/password
+      # Submits a new password using the token from the email. 422 on invalid
+      # or expired token; specific error key lets the client distinguish.
+      def update
+        resource = User.reset_password_by_token(reset_password_params)
+
+        if resource.errors.empty?
+          render json: {
+            status: { code: 200, message: 'Password has been reset successfully.' }
+          }, status: :ok
+        else
+          render json: {
+            status: {
+              code: 422,
+              message: resource.errors.full_messages.to_sentence,
+              errors: resource.errors.as_json
+            }
+          }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def reset_password_params
+        params.require(:user).permit(:reset_password_token, :password, :password_confirmation)
+      end
+    end
+  end
+end

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,11 +1,10 @@
-<% reset_url = "#{ENV.fetch('PASSWORD_RESET_URL', "https://#{ENV.fetch('APP_HOST', 'personal-coach.app')}/reset-password")}?reset_password_token=#{@token}" %>
 <p>Hi <%= @resource.email %>,</p>
 
-<p>Someone requested a password reset for your Personal Coach account. If that was you, click the link below to choose a new password:</p>
+<p>Someone requested a password reset for your Personal Coach account. If that was you, open the Personal Coach app, request a password reset, and enter the code below to choose a new password:</p>
 
-<p><a href="<%= reset_url %>"><%= reset_url %></a></p>
+<p style="font-family: monospace; font-size: 16px;"><strong><%= @token %></strong></p>
 
-<p>This link expires in <%= Devise.reset_password_within.inspect %>.</p>
+<p>This code expires in <%= Devise.reset_password_within.inspect %>.</p>
 
 <p>If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
 

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,12 @@
+<% reset_url = "#{ENV.fetch('PASSWORD_RESET_URL', "https://#{ENV.fetch('APP_HOST', 'personal-coach.app')}/reset-password")}?reset_password_token=#{@token}" %>
+<p>Hi <%= @resource.email %>,</p>
+
+<p>Someone requested a password reset for your Personal Coach account. If that was you, click the link below to choose a new password:</p>
+
+<p><a href="<%= reset_url %>"><%= reset_url %></a></p>
+
+<p>This link expires in <%= Devise.reset_password_within.inspect %>.</p>
+
+<p>If you didn't request a password reset, you can safely ignore this email — your password will not change.</p>
+
+<p>— Personal Coach</p>

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,12 @@
+<% reset_url = "#{ENV.fetch('PASSWORD_RESET_URL', "https://#{ENV.fetch('APP_HOST', 'personal-coach.app')}/reset-password")}?reset_password_token=#{@token}" %>
+Hi <%= @resource.email %>,
+
+Someone requested a password reset for your Personal Coach account. If that was you, open the link below to choose a new password:
+
+<%= reset_url %>
+
+This link expires in <%= Devise.reset_password_within.inspect %>.
+
+If you didn't request a password reset, you can safely ignore this email — your password will not change.
+
+— Personal Coach

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,11 +1,10 @@
-<% reset_url = "#{ENV.fetch('PASSWORD_RESET_URL', "https://#{ENV.fetch('APP_HOST', 'personal-coach.app')}/reset-password")}?reset_password_token=#{@token}" %>
 Hi <%= @resource.email %>,
 
-Someone requested a password reset for your Personal Coach account. If that was you, open the link below to choose a new password:
+Someone requested a password reset for your Personal Coach account. If that was you, open the Personal Coach app, request a password reset, and enter the code below to choose a new password:
 
-<%= reset_url %>
+  <%= @token %>
 
-This link expires in <%= Devise.reset_password_within.inspect %>.
+This code expires in <%= Devise.reset_password_within.inspect %>.
 
 If you didn't request a password reset, you can safely ignore this email — your password will not change.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,8 @@ module Server
     # Default From / Reply-To for all transactional mail (overridable per-mailer).
     # Sending domain SPF/DKIM/return-path must be configured separately at the DNS provider.
     config.action_mailer.default_options = {
-      from: ENV.fetch('FROM_MAIL_ADDRESS', 'no-reply@personal-coach.app'),
-      reply_to: ENV.fetch('FROM_MAIL_ADDRESS', 'no-reply@personal-coach.app')
+      from: ENV.fetch('MAIL_FROM_ADDRESS', 'no-reply@personal-coach.app'),
+      reply_to: ENV.fetch('MAIL_FROM_ADDRESS', 'no-reply@personal-coach.app')
     }
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV.fetch('FROM_MAIL_ADDRESS', 'no-reply@personal-coach.app')
+  config.mailer_sender = ENV.fetch('MAIL_FROM_ADDRESS', 'no-reply@personal-coach.app')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV.fetch('FROM_MAIL_ADDRESS', 'no-reply@personal-coach.app')
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
         registration: 'signup'
       }, controllers: {
         sessions: 'api/v1/sessions',
-        registrations: 'api/v1/registrations'
+        registrations: 'api/v1/registrations',
+        passwords: 'api/v1/passwords'
       }
 
       # Authentication routes

--- a/spec/requests/api/v1/passwords_controller_spec.rb
+++ b/spec/requests/api/v1/passwords_controller_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Passwords', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe 'POST /api/v1/password' do
+    let!(:user) { create(:user, email: 'reset-me@example.com') }
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    context 'when the email is registered' do
+      it 'returns 200 and queues a reset instructions email' do
+        expect do
+          post '/api/v1/password', params: { user: { email: user.email } }
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        expect(response).to have_http_status(:ok)
+
+        delivered = ActionMailer::Base.deliveries.last
+        expect(delivered.to).to include(user.email)
+        expect(delivered.subject).to match(/reset/i)
+
+        user.reload
+        expect(user.reset_password_token).to be_present
+        expect(user.reset_password_sent_at).to be_within(5.seconds).of(Time.current)
+      end
+
+      it 'normalizes email casing and whitespace before lookup' do
+        expect do
+          post '/api/v1/password', params: { user: { email: "  #{user.email.upcase}  " } }
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when the email is not registered' do
+      it 'still returns 200 and sends no email (no enumeration)' do
+        expect do
+          post '/api/v1/password', params: { user: { email: 'nobody@example.com' } }
+        end.not_to(change { ActionMailer::Base.deliveries.size })
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig('status', 'message')).to match(/if that email is registered/i)
+      end
+    end
+
+    context 'when the email is missing' do
+      it 'returns 200 and sends no email' do
+        expect do
+          post '/api/v1/password', params: { user: { email: '' } }
+        end.not_to(change { ActionMailer::Base.deliveries.size })
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/password' do
+    let(:user) { create(:user, password: 'oldpassword123', password_confirmation: 'oldpassword123') }
+    let(:raw_token) { user.send_reset_password_instructions }
+
+    context 'with a valid token and matching password confirmation' do
+      it 'resets the password and clears the token' do
+        put '/api/v1/password', params: {
+          user: {
+            reset_password_token: raw_token,
+            password: 'newpassword456',
+            password_confirmation: 'newpassword456'
+          }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.dig('status', 'message')).to match(/reset successfully/i)
+
+        user.reload
+        expect(user.valid_password?('newpassword456')).to be true
+        expect(user.valid_password?('oldpassword123')).to be false
+        expect(user.reset_password_token).to be_nil
+      end
+    end
+
+    context 'with an expired token' do
+      it 'returns 422 and does not change the password' do
+        token = travel_to((Devise.reset_password_within + 1.hour).ago) { user.send_reset_password_instructions }
+
+        put '/api/v1/password', params: {
+          user: {
+            reset_password_token: token,
+            password: 'newpassword456',
+            password_confirmation: 'newpassword456'
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body.dig('status', 'message')).to match(/expired/i)
+
+        user.reload
+        expect(user.valid_password?('oldpassword123')).to be true
+      end
+    end
+
+    context 'with an invalid token' do
+      it 'returns 422 and does not change the password' do
+        put '/api/v1/password', params: {
+          user: {
+            reset_password_token: 'totally-bogus-token',
+            password: 'newpassword456',
+            password_confirmation: 'newpassword456'
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body.dig('status', 'message')).to match(/invalid/i)
+
+        user.reload
+        expect(user.valid_password?('oldpassword123')).to be true
+      end
+    end
+
+    context 'when password and confirmation do not match' do
+      it 'returns 422 and reports the mismatch' do
+        put '/api/v1/password', params: {
+          user: {
+            reset_password_token: raw_token,
+            password: 'newpassword456',
+            password_confirmation: 'mismatch789'
+          }
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body.dig('status', 'message')).to match(/confirmation/i)
+
+        user.reload
+        expect(user.valid_password?('oldpassword123')).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Summary**

- Implements password reset flow via Devise's `:recoverable` module with JSON API endpoints and branded email templates.
- Sends reset token directly in email for users to copy and paste into the mobile app (no deep links).

**Why**

- PC-A2 — locked-out trial users without a recovery path abandon the trial silently. The transactional email pipeline (PC-A1, SendGrid) and global toast system (PC-F1) are already in `Done`.
- Deep links (`personalcoach://`) are not recognized by system browsers without universal/app link infrastructure (associated domains, AASA, assetlinks.json, intent filters), which is a multi-day ops project. Users opening reset emails on desktop would also have no path forward.

**How**

- Added `Api::V1::PasswordsController` with `POST /api/v1/password` (request reset, always 200 to prevent email enumeration) and `PUT /api/v1/password` (submit new password with token, 422 on invalid/expired).
- Point Devise mailer sender at `MAIL_FROM_ADDRESS` env var to match project-wide transactional mail config.
- Email templates display reset token as copyable code; user pastes it into app's reset screen (no clickable link).
- Specs cover happy path, expired/invalid tokens, mismatched confirmation, unknown email enumeration protection, and email normalization (8 examples).

**Trade-offs**

- Manual code entry trades convenience for universal compatibility — works on any device/surface today without universal link setup.