### PR TITLE
feat: send welcome email on sign-up (PC-A3)

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UserMailer < ApplicationMailer
+  def welcome(user)
+    @user = user
+
+    mail(
+      to: user.email,
+      subject: 'Welcome to Personal Coach'
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, on: :create
 
   after_create :create_profile
+  after_commit :send_welcome_email, on: :create
 
   def jwt_payload
     {
@@ -35,5 +36,11 @@ class User < ApplicationRecord
 
   def create_profile
     build_profile.save!
+  end
+
+  def send_welcome_email
+    return unless Rails.configuration.x.welcome_email.enabled
+
+    UserMailer.welcome(self).deliver_later
   end
 end

--- a/app/views/user_mailer/welcome.html.erb
+++ b/app/views/user_mailer/welcome.html.erb
@@ -1,0 +1,12 @@
+<p>Welcome to Personal Coach!</p>
+
+<p>Your account (<strong><%= @user.email %></strong>) is ready to go.</p>
+
+<p>Here's what to do next:</p>
+<ol>
+  <li>Finish onboarding so we can tailor coaching to your goals.</li>
+  <li>Capture your first SMART goal and break it into tasks.</li>
+  <li>Check in daily &mdash; small consistent steps compound fast.</li>
+</ol>
+
+<p>&mdash; The Personal Coach team</p>

--- a/app/views/user_mailer/welcome.text.erb
+++ b/app/views/user_mailer/welcome.text.erb
@@ -1,0 +1,11 @@
+Welcome to Personal Coach!
+
+Your account (<%= @user.email %>) is ready to go.
+
+Here's what to do next:
+
+  1. Finish onboarding so we can tailor coaching to your goals.
+  2. Capture your first SMART goal and break it into tasks.
+  3. Check in daily — small consistent steps compound fast.
+
+— The Personal Coach team

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,5 +43,10 @@ module Server
       from: ENV.fetch('MAIL_FROM_ADDRESS', 'no-reply@personal-coach.app'),
       reply_to: ENV.fetch('MAIL_FROM_ADDRESS', 'no-reply@personal-coach.app')
     }
+
+    # Transactional flows triggered from model callbacks. Disabled in test by
+    # default so factory-driven user creation does not enqueue real jobs;
+    # specs that exercise the flow opt in explicitly.
+    config.x.welcome_email.enabled = true
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,8 @@ Rails.application.configure do
 
   # Use inline job processing for tests
   config.active_job.queue_adapter = :test
+
+  # Suppress welcome-email enqueue from User#after_commit during the test
+  # suite — opt back in per-spec when verifying the welcome flow.
+  config.x.welcome_email.enabled = false
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UserMailer, type: :mailer do
+  describe '#welcome' do
+    let(:user) { create(:user, email: 'new-user@example.com') }
+    let(:mail) { described_class.welcome(user) }
+
+    it 'addresses the new user' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'uses the configured default From address' do
+      expect(mail.from).to eq([Rails.application.config.action_mailer.default_options.fetch(:from)])
+    end
+
+    it 'uses the configured default Reply-To address' do
+      expect(mail.reply_to).to eq([Rails.application.config.action_mailer.default_options.fetch(:reply_to)])
+    end
+
+    it 'has a welcome subject' do
+      expect(mail.subject).to eq('Welcome to Personal Coach')
+    end
+
+    it 'renders both text and html parts' do
+      expect(mail.body.parts.map(&:content_type)).to include(
+        a_string_starting_with('text/plain'),
+        a_string_starting_with('text/html')
+      )
+    end
+
+    it 'mentions the user email in both parts' do
+      bodies = mail.body.parts.map { |p| p.body.to_s }
+      expect(bodies).to all(include(user.email))
+    end
+
+    it 'mentions the next-step onboarding cue' do
+      html = mail.body.parts.find { |p| p.content_type.start_with?('text/html') }.body.to_s
+      expect(html).to match(/onboarding/i)
+    end
+  end
+end

--- a/spec/models/user_welcome_email_spec.rb
+++ b/spec/models/user_welcome_email_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'welcome email on signup' do
+    let(:attrs) do
+      {
+        email: Faker::Internet.unique.email,
+        password: 'password123',
+        password_confirmation: 'password123'
+      }
+    end
+
+    around do |example|
+      original = Rails.configuration.x.welcome_email.enabled
+      example.run
+    ensure
+      Rails.configuration.x.welcome_email.enabled = original
+    end
+
+    context 'when welcome email is enabled' do
+      before { Rails.configuration.x.welcome_email.enabled = true }
+
+      it 'enqueues UserMailer.welcome after commit on create' do
+        expect { described_class.create!(attrs) }
+          .to have_enqueued_mail(UserMailer, :welcome)
+      end
+
+      it 'does not enqueue on update' do
+        user = described_class.create!(attrs)
+        expect { user.update!(email: Faker::Internet.unique.email) }
+          .not_to have_enqueued_mail(UserMailer, :welcome)
+      end
+
+      it 'does not enqueue when validation fails' do
+        expect { described_class.create(attrs.merge(email: nil)) }
+          .not_to have_enqueued_mail(UserMailer, :welcome)
+      end
+    end
+
+    context 'when welcome email is disabled' do
+      before { Rails.configuration.x.welcome_email.enabled = false }
+
+      it 'does not enqueue any mail' do
+        expect { described_class.create!(attrs) }
+          .not_to have_enqueued_mail(UserMailer, :welcome)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Sends a transactional welcome email when a new user account is created, completing the second flow on top of the SendGrid pipeline that landed in PC-A1. The mail goes out from a Sidekiq job enqueued by an `after_commit` callback on `User`, so registration latency is unaffected and signup still succeeds even if SendGrid is briefly unavailable (the job will be retried).

The trigger is gated by a new `config.x.welcome_email.enabled` flag — on by default, off in the test environment so factory-driven `User` creation across the existing suite does not enqueue real mailer jobs. Specs that exercise the welcome flow opt in explicitly.

### Why
Confirms account creation, sets expectations, and primes engagement at the highest-attention moment of the trial. PC-A3 sub-ticket of PC-A.

## Changes
- `app/mailers/user_mailer.rb`
  - New `UserMailer#welcome(user)` action; `from`/`reply_to` inherited from the global `action_mailer.default_options`.
- `app/views/user_mailer/welcome.html.erb`, `app/views/user_mailer/welcome.text.erb`
  - HTML + plain-text templates confirming the new account and pointing the user toward onboarding, first SMART goal, and daily check-in.
- `app/models/user.rb`
  - Added `after_commit :send_welcome_email, on: :create` that calls `UserMailer.welcome(self).deliver_later` when the flag is enabled.
- `config/application.rb`
  - Declared `config.x.welcome_email.enabled = true` (default on for dev/prod).
- `config/environments/test.rb`
  - Override to `false` so factory-driven user creation across the suite does not enqueue mailer jobs.
- `spec/mailers/user_mailer_spec.rb`
  - Covers recipient, default From / Reply-To, subject, multipart rendering, and that both parts mention the user's email and the onboarding next-step cue.
- `spec/models/user_welcome_email_spec.rb`
  - With the flag enabled: enqueues `UserMailer.welcome` only on create (not update, not on validation failure). With the flag disabled: never enqueues. Around-block restores the flag between examples.

## Test Plan
- [x] `bin/rubocop app/mailers/user_mailer.rb app/models/user.rb spec/mailers/user_mailer_spec.rb spec/models/user_welcome_email_spec.rb` — clean (0 offenses)
- [x] `ruby -c` on every touched .rb file — Syntax OK
- [ ] `bundle exec rspec spec/mailers/user_mailer_spec.rb spec/models/user_welcome_email_spec.rb` — deferred locally (test DB password not available in shell env); run on CI / before merge.
- [ ] Manual: create a user in development against a real SendGrid sandbox key and confirm the welcome email arrives and renders correctly in HTML and plain-text clients.

## Additional Notes
- Depends on PC-A1 (SendGrid wiring) — already merged.
- The flag intentionally lives in `config.x.welcome_email.enabled` rather than an ENV var so tests can flip it per-example without process restarts. If we add more transactional flows we can promote `config.x.<flow>.enabled` into a small registry, but premature for one mailer.
- Subject is plain `Welcome to Personal Coach` (no environment tag), unlike `TestMailer#ping`. The ping subject tags the env because it's an internal deliverability probe; the welcome email is user-facing.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 201.03ms | ✅ |
| **90th Percentile Latency** | 181.46ms | - |
| **Average Latency** | 74.14ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 678 requests, 678 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 198.22ms | ✅ |
| **90th Percentile Latency** | 192.15ms | - |
| **Average Latency** | 75.60ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 672 requests, 672 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 195.84ms | ✅ |
| **90th Percentile Latency** | 187.57ms | - |
| **Average Latency** | 77.30ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 672 requests, 672 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 170.29ms | ✅ |
| **90th Percentile Latency** | 149.73ms | - |
| **Average Latency** | 60.46ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 699 requests, 466 checks passed, 233 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 213.26ms | ✅ |
| **90th Percentile Latency** | 203.96ms | - |
| **Average Latency** | 74.54ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 678 requests, 678 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1770.55ms | ✅ |
| **90th Percentile Latency** | 1650.57ms | - |
| **Average Latency** | 792.70ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 183.05ms | ✅ |
| **90th Percentile Latency** | 172.96ms | - |
| **Average Latency** | 69.50ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 681 requests, 681 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 212.13ms | ✅ |
| **90th Percentile Latency** | 206.30ms | - |
| **Average Latency** | 80.55ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 663 requests, 442 checks passed, 221 checks failed

---

<!-- PERF_RESULTS_END -->