### PR TITLE
feat: backend for goal ↔ task connection UX (PC-B1, PC-B2, PC-B3)

### DIFF
--- a/app/controllers/api/v1/smart_goals_controller.rb
+++ b/app/controllers/api/v1/smart_goals_controller.rb
@@ -3,12 +3,18 @@
 module Api
   module V1
     class SmartGoalsController < ApplicationController
+      MAX_TASKS_PER_SECTION = 50
+
       before_action :authenticate_api_v1_user!
-      before_action :set_smart_goal, only: %i[update destroy]
+      before_action :set_smart_goal, only: %i[show update destroy]
 
       def index
         smart_goals = current_api_v1_profile.smart_goals
         render json: smart_goals
+      end
+
+      def show
+        render json: @smart_goal.as_json.merge('tasks' => sectioned_tasks(@smart_goal))
       end
 
       def create
@@ -45,6 +51,13 @@ module Api
 
       def set_smart_goal
         @smart_goal = current_api_v1_profile.smart_goals.find(params[:id])
+      end
+
+      def sectioned_tasks(smart_goal)
+        {
+          'open' => smart_goal.tasks.incomplete.order(created_at: :desc).limit(MAX_TASKS_PER_SECTION).as_json,
+          'completed' => smart_goal.tasks.completed.order(updated_at: :desc).limit(MAX_TASKS_PER_SECTION).as_json
+        }
       end
     end
   end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -58,7 +58,9 @@ module Api
       end
 
       def task_params
-        params.require(:task).permit(:title, :description, :completed, :action_category, :priority)
+        params.require(:task).permit(
+          :title, :description, :completed, :action_category, :priority, :smart_goal_id, :due_at
+        )
       end
     end
   end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -4,27 +4,26 @@ module Api
   module V1
     # Controller for managing user tasks
     class TasksController < ApplicationController
+      TASK_JSON_OPTIONS = { include: { smart_goal: { only: %i[id title] } } }.freeze
+
       before_action :authenticate_api_v1_user!
       before_action :set_task, only: %i[show update destroy]
 
       def index
-        @tasks = if params[:completed].present?
-                   current_api_v1_profile.tasks.where(completed: params[:completed])
-                 else
-                   current_api_v1_profile.tasks
-                 end
+        scope = current_api_v1_profile.tasks.includes(:smart_goal)
+        @tasks = params[:completed].present? ? scope.where(completed: params[:completed]) : scope
 
-        render json: @tasks
+        render json: @tasks.as_json(TASK_JSON_OPTIONS)
       end
 
       def show
-        render json: @task
+        render json: @task.as_json(TASK_JSON_OPTIONS)
       end
 
       def create
         @task = current_api_v1_profile.tasks.build(task_params)
         if @task.save
-          render json: @task, status: :created
+          render json: @task.as_json(TASK_JSON_OPTIONS), status: :created
         else
           render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
         end
@@ -36,7 +35,7 @@ module Api
 
       def update
         if @task.update(task_params)
-          render json: @task
+          render json: @task.as_json(TASK_JSON_OPTIONS)
         else
           render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
         end
@@ -54,7 +53,7 @@ module Api
       private
 
       def set_task
-        @task = current_api_v1_profile.tasks.find(params[:id])
+        @task = current_api_v1_profile.tasks.includes(:smart_goal).find(params[:id])
       end
 
       def task_params

--- a/spec/requests/api/v1/smart_goals_controller_spec.rb
+++ b/spec/requests/api/v1/smart_goals_controller_spec.rb
@@ -59,6 +59,107 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
     end
   end
 
+  describe 'GET /api/v1/smart_goals/:id' do
+    let!(:smart_goal) { create(:smart_goal, profile: profile) }
+
+    it 'returns the smart goal with all expected attributes' do
+      get api_v1_smart_goal_path(smart_goal)
+
+      expect(response).to have_http_status(:ok)
+      json_response = response.parsed_body
+
+      expect(json_response).to include(
+        'id', 'title', 'description', 'timeframe',
+        'specific', 'measurable', 'achievable', 'relevant', 'time_bound',
+        'completed', 'target_date', 'profile_id', 'tasks'
+      )
+      expect(json_response['id']).to eq(smart_goal.id)
+    end
+
+    context 'with linked tasks' do
+      let!(:open_task)      { create(:task, profile: profile, smart_goal: smart_goal, completed: false) }
+      let!(:other_open)     { create(:task, profile: profile, smart_goal: smart_goal, completed: false) }
+      let!(:completed_task) { create(:task, profile: profile, smart_goal: smart_goal, completed: true) }
+      let!(:unlinked_task)  { create(:task, profile: profile, smart_goal: nil, completed: false) }
+
+      it 'separates tasks into open and completed sections' do
+        get api_v1_smart_goal_path(smart_goal)
+
+        json_response = response.parsed_body
+        open_ids = json_response['tasks']['open'].pluck('id')
+        completed_ids = json_response['tasks']['completed'].pluck('id')
+
+        expect(open_ids).to contain_exactly(open_task.id, other_open.id)
+        expect(completed_ids).to eq([completed_task.id])
+      end
+
+      it 'excludes tasks belonging to other goals or no goal' do
+        get api_v1_smart_goal_path(smart_goal)
+
+        json_response = response.parsed_body
+        all_ids = json_response['tasks']['open'].pluck('id') + json_response['tasks']['completed'].pluck('id')
+
+        expect(all_ids).not_to include(unlinked_task.id)
+      end
+
+      it 'returns expected task attributes' do
+        get api_v1_smart_goal_path(smart_goal)
+
+        json_response = response.parsed_body
+        task = json_response['tasks']['open'].first
+
+        expect(task).to include(
+          'id', 'title', 'description', 'completed',
+          'action_category', 'priority', 'due_at', 'smart_goal_id'
+        )
+      end
+    end
+
+    context 'with no linked tasks' do
+      it 'returns empty arrays for both sections' do
+        get api_v1_smart_goal_path(smart_goal)
+
+        json_response = response.parsed_body
+        expect(json_response['tasks']['open']).to eq([])
+        expect(json_response['tasks']['completed']).to eq([])
+      end
+    end
+
+    context 'when more than 50 tasks per section exist' do
+      before do
+        create_list(:task, 51, profile: profile, smart_goal: smart_goal, completed: false)
+        create_list(:task, 51, profile: profile, smart_goal: smart_goal, completed: true)
+      end
+
+      it 'caps each section at 50 entries' do
+        get api_v1_smart_goal_path(smart_goal)
+
+        json_response = response.parsed_body
+        expect(json_response['tasks']['open'].size).to eq(50)
+        expect(json_response['tasks']['completed'].size).to eq(50)
+      end
+    end
+
+    context 'when smart goal does not exist' do
+      it 'returns not found status' do
+        get api_v1_smart_goal_path(999_999)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when smart goal belongs to a different user' do
+      let!(:other_user) { create(:user) }
+      let!(:other_smart_goal) { create(:smart_goal, profile: other_user.profile) }
+
+      it 'returns not found status' do
+        get api_v1_smart_goal_path(other_smart_goal)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'POST /api/v1/smart_goals' do
     context 'with valid parameters' do
       let(:valid_params) do

--- a/spec/requests/api/v1/tasks_controller_spec.rb
+++ b/spec/requests/api/v1/tasks_controller_spec.rb
@@ -51,6 +51,23 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
         expect(json_response).to eq([])
       end
     end
+
+    context 'when a task has a linked smart goal' do
+      let!(:smart_goal) { create(:smart_goal, profile: profile, title: 'Ship PC-B') }
+      let!(:linked_task)   { create(:task, profile: profile, smart_goal: smart_goal) }
+      let!(:unlinked_task) { create(:task, profile: profile, smart_goal: nil) }
+
+      it 'embeds the parent goal id and title on linked tasks' do
+        get api_v1_tasks_path
+
+        json_response = response.parsed_body
+        linked = json_response.find { |t| t['id'] == linked_task.id }
+        unlinked = json_response.find { |t| t['id'] == unlinked_task.id }
+
+        expect(linked['smart_goal']).to eq('id' => smart_goal.id, 'title' => 'Ship PC-B')
+        expect(unlinked['smart_goal']).to be_nil
+      end
+    end
   end
 
   describe 'GET /api/v1/tasks/:id' do
@@ -68,6 +85,18 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
         expect(json_response['description']).to eq(task.description)
         expect(json_response['completed']).to eq(task.completed)
         expect(json_response['action_category']).to eq(task.action_category)
+      end
+    end
+
+    context 'when task has a linked smart goal' do
+      let!(:smart_goal) { create(:smart_goal, profile: profile, title: 'Ship PC-B') }
+      let!(:linked_task) { create(:task, profile: profile, smart_goal: smart_goal) }
+
+      it 'embeds the parent goal id and title' do
+        get api_v1_task_path(linked_task)
+
+        json_response = response.parsed_body
+        expect(json_response['smart_goal']).to eq('id' => smart_goal.id, 'title' => 'Ship PC-B')
       end
     end
 

--- a/spec/requests/api/v1/tasks_controller_spec.rb
+++ b/spec/requests/api/v1/tasks_controller_spec.rb
@@ -173,6 +173,27 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
         end
       end
     end
+
+    context 'when linking a task to a smart goal' do
+      let!(:smart_goal) { create(:smart_goal, profile: profile) }
+      let(:linked_task_params) do
+        {
+          task: {
+            title: 'Task linked to a goal',
+            action_category: 'do',
+            smart_goal_id: smart_goal.id
+          }
+        }
+      end
+
+      it 'persists the smart_goal_id' do
+        post api_v1_tasks_path, params: linked_task_params
+
+        expect(response).to have_http_status(:created)
+        json_response = response.parsed_body
+        expect(json_response['smart_goal_id']).to eq(smart_goal.id)
+      end
+    end
   end
 
   describe 'PATCH /api/v1/tasks/:id' do


### PR DESCRIPTION
## Summary
Backend half of PC-B: makes the existing `tasks.smart_goal_id` FK queryable, writable, and visible through the API. Adds a `show` action on `SmartGoalsController` that returns the goal along with its linked tasks split into `open` and `completed` sections (capped at 50 per section). Opens `task_params` to accept `smart_goal_id` and `due_at` so the client's create/edit flows can persist a goal link. Embeds `smart_goal: { id, title }` on every task payload (`index`, `show`, `create`, `update`) so the client can render the parent-goal pill on each task row without an N+1 fetch — `:smart_goal` is eager-loaded on `index` and `set_task` to keep the addition O(1).

### Why
Companion to [personal-coach-client#17](https://github.com/J-pilon/personal-coach-client/pull/17), which is the user-facing half. Without these endpoints the goal detail screen has nothing to load, the addTask/taskDetail goal selectors have nothing to persist, and the per-row goal pill has nothing to render. The two PRs need to land in the same release.

## Changes
- `app/controllers/api/v1/smart_goals_controller.rb`
  - New `show` action and `MAX_TASKS_PER_SECTION = 50` constant.
  - Private `sectioned_tasks` helper returns `open` (incomplete, `created_at DESC`, limit 50) and `completed` (`updated_at DESC`, limit 50).
- `app/controllers/api/v1/tasks_controller.rb`
  - `task_params` permits `:smart_goal_id` and `:due_at`.
  - Adds `TASK_JSON_OPTIONS = { include: { smart_goal: { only: %i[id title] } } }`.
  - `index`, `show`, `create`, `update` render through that envelope; `index` and `set_task` eager-load `:smart_goal`.
- `spec/requests/api/v1/smart_goals_controller_spec.rb`
  - New `GET /api/v1/smart_goals/:id` block: payload shape, sectioning, exclusion of unrelated/unlinked tasks, empty-state, 50-cap per section, 404 on missing id and cross-tenant.
- `spec/requests/api/v1/tasks_controller_spec.rb`
  - Specs for linking on create, and for `smart_goal: { id, title }` embedding on `index` and `show` (with `nil` on unlinked tasks).

## Test Plan
- [x] `bundle exec rubocop` on touched files — clean.
- [ ] `bundle exec rspec spec/requests/api/v1/smart_goals_controller_spec.rb spec/requests/api/v1/tasks_controller_spec.rb` — pending (local Postgres role currently requires a password not present in `.env`; CI will exercise).
- [ ] Manual via curl: `GET /api/v1/smart_goals/:id` returns the goal plus `tasks.open` / `tasks.completed`.
- [ ] Manual via curl: `GET /api/v1/tasks` returns `smart_goal: { id, title }` on linked rows and `nil` on unlinked.

## Additional Notes
- Pagination on the sectioned task list is intentionally deferred — the 50-cap-per-section is enough until a user actually hits it. If/when that happens, add `?tasks_page=`/`?tasks_per_page=` rather than expanding the cap.
- The `smart_goal` embed deliberately exposes only `id` and `title` — keeps the payload tight and avoids leaking the full SMART fields onto every task list response.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 287.13ms | ✅ |
| **90th Percentile Latency** | 265.46ms | - |
| **Average Latency** | 116.59ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 627 requests, 627 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 273.53ms | ✅ |
| **90th Percentile Latency** | 259.06ms | - |
| **Average Latency** | 112.91ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 633 requests, 633 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 293.89ms | ✅ |
| **90th Percentile Latency** | 274.86ms | - |
| **Average Latency** | 112.27ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 633 requests, 633 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 255.81ms | ✅ |
| **90th Percentile Latency** | 230.88ms | - |
| **Average Latency** | 93.44ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 648 requests, 432 checks passed, 216 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 267.38ms | ✅ |
| **90th Percentile Latency** | 259.68ms | - |
| **Average Latency** | 110.02ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 636 requests, 636 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1912.52ms | ✅ |
| **90th Percentile Latency** | 1761.29ms | - |
| **Average Latency** | 859.22ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 271.54ms | ✅ |
| **90th Percentile Latency** | 255.08ms | - |
| **Average Latency** | 109.41ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 633 requests, 633 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 282.03ms | ✅ |
| **90th Percentile Latency** | 269.77ms | - |
| **Average Latency** | 121.80ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 627 requests, 418 checks passed, 209 checks failed

---

<!-- PERF_RESULTS_END -->