### PR TITLE
feat: add Journal + JournalEntry data layer (PC-J1)

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Journal < ApplicationRecord
+  belongs_to :profile
+  has_many :journal_entries, dependent: :destroy
+
+  enum :kind, { default: 'default' }
+
+  validates :title, presence: true
+  validates :kind, presence: true
+  validates :profile_id, uniqueness: { scope: :kind }
+end

--- a/app/models/journal_entry.rb
+++ b/app/models/journal_entry.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class JournalEntry < ApplicationRecord
+  belongs_to :profile
+  belongs_to :journal
+
+  enum :entry_type, {
+    daily_journal: 'daily_journal',
+    weekly_reflection: 'weekly_reflection',
+    general: 'general'
+  }
+
+  validates :body, presence: true
+  validates :entry_type, presence: true
+  validates :occurred_on, presence: true
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,6 +9,8 @@ class Profile < ApplicationRecord
   has_many :tickets, dependent: :destroy
   has_many :notifications, dependent: :destroy
   has_many :device_tokens, dependent: :destroy
+  has_many :journals, dependent: :destroy
+  has_many :journal_entries, dependent: :destroy
   has_one :notification_preference, dependent: :destroy
 
   # Notification scopes

--- a/app/services/default_journal_finder.rb
+++ b/app/services/default_journal_finder.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Returns the profile's default journal, creating it on first access.
+# Keeps the "one default journal per profile" invariant in one place so
+# controllers and other services don't reinvent the seed defaults.
+class DefaultJournalFinder
+  DEFAULT_TITLE = 'My Journal'
+  DEFAULT_DESCRIPTION = 'Daily journals and weekly reflections'
+
+  def self.call(profile)
+    profile.journals.find_or_create_by!(kind: 'default') do |journal|
+      journal.title = DEFAULT_TITLE
+      journal.description = DEFAULT_DESCRIPTION
+    end
+  end
+end

--- a/db/migrate/20260521120000_create_journals.rb
+++ b/db/migrate/20260521120000_create_journals.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateJournals < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journals do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.string :title, null: false
+      t.string :description
+      t.string :kind, null: false, default: 'default'
+
+      t.timestamps
+    end
+
+    add_index :journals, %i[profile_id kind], unique: true
+  end
+end

--- a/db/migrate/20260521120100_create_journal_entries.rb
+++ b/db/migrate/20260521120100_create_journal_entries.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateJournalEntries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journal_entries do |t|
+      t.references :profile, null: false, foreign_key: true
+      t.references :journal, null: false, foreign_key: true
+      t.string :title
+      t.text :body, null: false
+      t.string :entry_type, null: false
+      t.date :occurred_on, null: false
+
+      t.timestamps
+    end
+
+    add_index :journal_entries, %i[profile_id occurred_on]
+    add_index :journal_entries, %i[profile_id entry_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_12_214407) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_21_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,6 +46,32 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_12_214407) do
     t.index ["platform"], name: "index_device_tokens_on_platform"
     t.index ["profile_id", "token"], name: "index_device_tokens_on_profile_id_and_token", unique: true
     t.index ["profile_id"], name: "index_device_tokens_on_profile_id"
+  end
+
+  create_table "journal_entries", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.bigint "journal_id", null: false
+    t.string "title"
+    t.text "body", null: false
+    t.string "entry_type", null: false
+    t.date "occurred_on", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journal_id"], name: "index_journal_entries_on_journal_id"
+    t.index ["profile_id", "entry_type"], name: "index_journal_entries_on_profile_id_and_entry_type"
+    t.index ["profile_id", "occurred_on"], name: "index_journal_entries_on_profile_id_and_occurred_on"
+    t.index ["profile_id"], name: "index_journal_entries_on_profile_id"
+  end
+
+  create_table "journals", force: :cascade do |t|
+    t.bigint "profile_id", null: false
+    t.string "title", null: false
+    t.string "description"
+    t.string "kind", default: "default", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id", "kind"], name: "index_journals_on_profile_id_and_kind", unique: true
+    t.index ["profile_id"], name: "index_journals_on_profile_id"
   end
 
   create_table "notification_preferences", force: :cascade do |t|
@@ -163,6 +189,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_12_214407) do
 
   add_foreign_key "ai_requests", "profiles"
   add_foreign_key "device_tokens", "profiles"
+  add_foreign_key "journal_entries", "journals"
+  add_foreign_key "journal_entries", "profiles"
+  add_foreign_key "journals", "profiles"
   add_foreign_key "notification_preferences", "profiles"
   add_foreign_key "notifications", "device_tokens"
   add_foreign_key "notifications", "profiles"

--- a/spec/factories/journal_entries.rb
+++ b/spec/factories/journal_entries.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :journal_entry do
+    association :profile
+    journal { association(:journal, profile: profile) }
+    title { 'Today' }
+    body { 'A quick reflection on the day.' }
+    entry_type { 'daily_journal' }
+    occurred_on { Date.current }
+
+    trait :weekly do
+      entry_type { 'weekly_reflection' }
+      title { 'Week in review' }
+    end
+
+    trait :general do
+      entry_type { 'general' }
+    end
+  end
+end

--- a/spec/factories/journals.rb
+++ b/spec/factories/journals.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :journal do
+    association :profile
+    title { 'My Journal' }
+    description { 'Daily journals, weekly reflections, and goal notes.' }
+    kind { 'default' }
+  end
+end

--- a/spec/models/journal_entry_spec.rb
+++ b/spec/models/journal_entry_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JournalEntry, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+    it { is_expected.to belong_to(:journal) }
+  end
+
+  describe 'validations' do
+    subject { build(:journal_entry) }
+
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_presence_of(:entry_type) }
+    it { is_expected.to validate_presence_of(:occurred_on) }
+  end
+
+  describe 'entry_type enum' do
+    it 'accepts every documented entry type' do
+      %w[daily_journal weekly_reflection general].each do |type|
+        entry = build(:journal_entry, entry_type: type)
+        expect(entry).to be_valid, "expected #{type} to be a valid entry_type"
+      end
+    end
+
+    it 'rejects unknown entry types' do
+      expect { build(:journal_entry, entry_type: 'rant') }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Journal, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+    it { is_expected.to have_many(:journal_entries).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    subject { create(:journal) }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:kind) }
+    it { is_expected.to validate_uniqueness_of(:profile_id).scoped_to(:kind) }
+  end
+
+  describe 'kind enum' do
+    it 'exposes default as a kind' do
+      journal = create(:journal)
+      expect(journal).to be_default
+    end
+
+    it 'rejects unknown kinds' do
+      expect { build(:journal, kind: 'mystery') }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe 'one default journal per profile' do
+    it 'prevents a profile from owning two default journals' do
+      profile = create(:profile)
+      create(:journal, profile: profile)
+
+      duplicate = build(:journal, profile: profile)
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:profile_id]).to be_present
+    end
+
+    it 'destroys child entries when the journal is deleted' do
+      journal = create(:journal)
+      create(:journal_entry, journal: journal, profile: journal.profile)
+
+      expect { journal.destroy }.to change(JournalEntry, :count).by(-1)
+    end
+  end
+end

--- a/spec/services/default_journal_finder_spec.rb
+++ b/spec/services/default_journal_finder_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DefaultJournalFinder do
+  describe '.call' do
+    let(:profile) { create(:profile) }
+
+    context 'when the profile has no journals yet' do
+      it 'creates a default journal seeded with the standard title and description' do
+        expect { described_class.call(profile) }.to change(Journal, :count).by(1)
+
+        journal = profile.journals.first
+        expect(journal.kind).to eq('default')
+        expect(journal.title).to eq(DefaultJournalFinder::DEFAULT_TITLE)
+        expect(journal.description).to eq(DefaultJournalFinder::DEFAULT_DESCRIPTION)
+      end
+    end
+
+    context 'when the profile already has a default journal' do
+      it 'returns the existing journal without creating a new one' do
+        existing = described_class.call(profile)
+
+        expect { described_class.call(profile) }.not_to change(Journal, :count)
+        expect(described_class.call(profile)).to eq(existing)
+      end
+    end
+
+    it 'scopes per profile (each profile gets its own default)' do
+      other = create(:profile)
+
+      mine = described_class.call(profile)
+      theirs = described_class.call(other)
+
+      expect(mine).not_to eq(theirs)
+      expect(mine.profile).to eq(profile)
+      expect(theirs.profile).to eq(other)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Lays the data foundation for the Journals & Reflections feature (parent PC-J). Adds `journals` and `journal_entries` tables — both scoped to `Profile` — with the supporting AR models, validations, and enums. Introduces `DefaultJournalFinder`, a thin service that lazily provisions a profile's one default journal so the upcoming API and UI tickets (PC-J2 / PC-J3 / PC-J4) consume one canonical lookup instead of reinventing it.

Schema is additive only — no existing tables touched and no data backfill. A unique `(profile_id, kind)` index guarantees the one-default-journal-per-profile invariant at the DB level so the app cannot quietly accumulate duplicates.

### Why
This is the data layer PC-J2 (API), PC-J3, and PC-J4 (RN screens) all depend on. Shipping it standalone keeps each follow-up ticket reviewable on its own and lets the other three sub-tickets parallelize off this base.

## Changes
- `db/migrate/20260521120000_create_journals.rb`
  - New `journals` table: `profile_id` (FK, null:false), `title` (null:false), `description`, `kind` (default `"default"`, null:false), timestamps.
  - Unique composite index on `(profile_id, kind)` to enforce one journal per kind per profile.
- `db/migrate/20260521120100_create_journal_entries.rb`
  - New `journal_entries` table: `profile_id` (FK), `journal_id` (FK), `title` (nullable), `body` (text, null:false), `entry_type` (null:false), `occurred_on` (date, null:false), timestamps.
  - Indexes on `(profile_id, occurred_on)` and `(profile_id, entry_type)` to back the filters planned in PC-J2.
- `db/schema.rb`
  - Regenerated to include the two new tables, indexes, and foreign keys.
- `app/models/journal.rb`
  - `belongs_to :profile`, `has_many :journal_entries (dependent: :destroy)`.
  - `enum :kind, { default: 'default' }`; presence validations on `title` and `kind`; `profile_id` uniqueness scoped to `kind`.
- `app/models/journal_entry.rb`
  - `belongs_to :profile`, `belongs_to :journal`.
  - `enum :entry_type, { daily_journal, weekly_reflection, general }`; presence validations on `body`, `entry_type`, `occurred_on`.
- `app/models/profile.rb`
  - Added `has_many :journals` and `has_many :journal_entries` (both `dependent: :destroy`).
- `app/services/default_journal_finder.rb`
  - `DefaultJournalFinder.call(profile)` — `find_or_create_by!(kind: 'default')` with seeded `DEFAULT_TITLE` / `DEFAULT_DESCRIPTION` constants. Centralizes the seed-copy and the "lazy default" idiom for PC-J2's controllers.
- `spec/factories/journals.rb`, `spec/factories/journal_entries.rb`
  - Factories with traits for `:weekly` and `:general` entries.
- `spec/models/journal_spec.rb`
  - Associations, presence validations, enum coverage, the one-default-per-profile uniqueness invariant, and `dependent: :destroy` for child entries.
- `spec/models/journal_entry_spec.rb`
  - Associations, presence validations, and enum acceptance / rejection.
- `spec/services/default_journal_finder_spec.rb`
  - Happy path (creates with seeded fields), idempotency (existing default is returned without a new insert), and per-profile scoping.

## Test Plan
- [x] `bundle exec rspec spec/models/journal_spec.rb spec/models/journal_entry_spec.rb spec/services/default_journal_finder_spec.rb` — 19 examples, 0 failures.
- [x] `bundle exec rspec spec/models/profile_spec.rb` — 26 examples, 0 failures (no regression from the new `has_many` associations).
- [x] `bundle exec rubocop` on all 11 new/modified files — no offenses.
- [x] `bundle exec rails db:migrate` ran cleanly in development.
- [ ] Heroku `release` migration run on merge.

## Additional Notes
- This ticket intentionally ships **no** controllers, routes, or request specs — that's PC-J2.
- The `kind` enum has a single value (`default`) today. The unique `(profile_id, kind)` index leaves room for future kinds (gratitude, fitness, etc.) without a schema change.
- The cross-profile invariant ("an entry's `profile_id` must match its `journal.profile_id`") is intentionally enforced at the controller/service layer in PC-J2 rather than as a model validation, per scope decision during implementation.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 261.85ms | ✅ |
| **90th Percentile Latency** | 248.55ms | - |
| **Average Latency** | 100.71ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 633 requests, 633 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 245.14ms | ✅ |
| **90th Percentile Latency** | 239.40ms | - |
| **Average Latency** | 94.49ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 252.79ms | ✅ |
| **90th Percentile Latency** | 237.94ms | - |
| **Average Latency** | 91.42ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 224.28ms | ✅ |
| **90th Percentile Latency** | 211.30ms | - |
| **Average Latency** | 85.39ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 651 requests, 434 checks passed, 217 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 254.97ms | ✅ |
| **90th Percentile Latency** | 242.21ms | - |
| **Average Latency** | 97.72ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1831.03ms | ✅ |
| **90th Percentile Latency** | 1600.86ms | - |
| **Average Latency** | 796.87ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 243.15ms | ✅ |
| **90th Percentile Latency** | 217.62ms | - |
| **Average Latency** | 90.23ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 248.95ms | ✅ |
| **90th Percentile Latency** | 240.80ms | - |
| **Average Latency** | 97.52ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 642 requests, 428 checks passed, 214 checks failed

---

<!-- PERF_RESULTS_END -->