### PR TITLE
feat: add journal API endpoints + JournalEntries::Create (PC-J2)

### DIFF
--- a/app/controllers/api/v1/journal_entries_controller.rb
+++ b/app/controllers/api/v1/journal_entries_controller.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # CRUD for journal entries scoped to the current profile.
+    # Index supports filtering by entry_type, exact occurred_on, and
+    # start_date/end_date range. The server picks the journal — clients
+    # never supply profile_id or journal_id.
+    class JournalEntriesController < ApplicationController
+      ENTRY_JSON_OPTIONS = {
+        only: %i[id journal_id profile_id title body entry_type occurred_on created_at updated_at]
+      }.freeze
+
+      before_action :authenticate_api_v1_user!
+      before_action :set_entry, only: %i[show update destroy]
+
+      def index
+        scope = current_api_v1_profile.journal_entries
+        scope = scope.where(entry_type: params[:entry_type]) if params[:entry_type].present?
+        scope = scope.where(occurred_on: params[:occurred_on]) if params[:occurred_on].present?
+        scope = scope.where(occurred_on: params[:start_date]..) if params[:start_date].present?
+        scope = scope.where(occurred_on: ..params[:end_date]) if params[:end_date].present?
+
+        @entries = scope.order(occurred_on: :desc, created_at: :desc)
+        render json: @entries.as_json(ENTRY_JSON_OPTIONS)
+      end
+
+      def show
+        render json: @entry.as_json(ENTRY_JSON_OPTIONS)
+      end
+
+      def create
+        @entry = JournalEntries::Create.call(profile: current_api_v1_profile, params: entry_params)
+        if @entry.persisted?
+          render json: @entry.as_json(ENTRY_JSON_OPTIONS), status: :created
+        else
+          render json: { errors: @entry.errors.full_messages }, status: :unprocessable_entity
+        end
+      rescue ArgumentError => e
+        raise e unless e.message.include?('entry_type')
+
+        render json: { errors: ['Entry type is not included in the list'] }, status: :unprocessable_entity
+      end
+
+      def update
+        if @entry.update(entry_params)
+          render json: @entry.as_json(ENTRY_JSON_OPTIONS)
+        else
+          render json: { errors: @entry.errors.full_messages }, status: :unprocessable_entity
+        end
+      rescue ArgumentError => e
+        raise e unless e.message.include?('entry_type')
+
+        render json: { errors: ['Entry type is not included in the list'] }, status: :unprocessable_entity
+      end
+
+      def destroy
+        @entry.destroy
+        head :no_content
+      end
+
+      private
+
+      def set_entry
+        @entry = current_api_v1_profile.journal_entries.find(params[:id])
+      end
+
+      def entry_params
+        params.require(:journal_entry).permit(:title, :body, :entry_type, :occurred_on)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/journals_controller.rb
+++ b/app/controllers/api/v1/journals_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Returns the current profile's default journal, lazily creating it
+    # the first time a profile asks for it.
+    class JournalsController < ApplicationController
+      JOURNAL_JSON_OPTIONS = { only: %i[id title description kind created_at updated_at] }.freeze
+
+      before_action :authenticate_api_v1_user!
+
+      def show
+        journal = DefaultJournalFinder.call(current_api_v1_profile)
+        render json: journal.as_json(JOURNAL_JSON_OPTIONS)
+      end
+    end
+  end
+end

--- a/app/services/journal_entries/create.rb
+++ b/app/services/journal_entries/create.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module JournalEntries
+  # Creates a journal entry under the profile's default journal,
+  # lazily provisioning the journal on first use. Centralizes the
+  # "the server decides which journal" rule so controllers never
+  # accept a client-supplied journal_id.
+  class Create
+    def self.call(profile:, params:)
+      journal = DefaultJournalFinder.call(profile)
+
+      journal.journal_entries.create(
+        profile: profile,
+        title: params[:title],
+        body: params[:body],
+        entry_type: params[:entry_type],
+        occurred_on: params[:occurred_on].presence || Date.current
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
         end
       end
       resources :smart_goals
+      resource :journal, only: %i[show] do
+        resources :journal_entries, only: %i[index show create update destroy]
+      end
       resources :tickets, only: %i[create show]
       post 'ai/proxy', to: 'ai#proxy'
       post 'ai/usage', to: 'ai#usage'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
 end
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 # Shoulda Matchers configuration
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/api/v1/journal_entries_controller_spec.rb
+++ b/spec/requests/api/v1/journal_entries_controller_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::JournalEntries', type: :request do
+  let!(:user) { create(:user) }
+  let!(:profile) { user.profile }
+  let!(:journal) { create(:journal, profile: profile) }
+
+  describe 'GET /api/v1/journal/journal_entries' do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        get api_v1_journal_journal_entries_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'returns only entries belonging to the current profile' do
+        mine = create(:journal_entry, profile: profile, journal: journal)
+        other_profile = create(:profile)
+        create(:journal_entry, profile: other_profile, journal: create(:journal, profile: other_profile))
+
+        get api_v1_journal_journal_entries_path
+
+        ids = response.parsed_body.pluck('id')
+        expect(ids).to eq([mine.id])
+      end
+
+      it 'orders entries by occurred_on desc, then created_at desc' do
+        older = create(:journal_entry, profile: profile, journal: journal, occurred_on: 3.days.ago.to_date)
+        newer = create(:journal_entry, profile: profile, journal: journal, occurred_on: Date.current)
+
+        get api_v1_journal_journal_entries_path
+
+        expect(response.parsed_body.pluck('id')).to eq([newer.id, older.id])
+      end
+
+      it 'returns an empty array when the profile has no entries' do
+        get api_v1_journal_journal_entries_path
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
+
+      context 'with filters' do
+        let!(:daily) do
+          create(:journal_entry, profile: profile, journal: journal, occurred_on: Date.new(2026, 5, 10))
+        end
+        let!(:weekly) do
+          create(:journal_entry, :weekly, profile: profile, journal: journal, occurred_on: Date.new(2026, 5, 17))
+        end
+        let!(:general) do
+          create(:journal_entry, :general, profile: profile, journal: journal, occurred_on: Date.new(2026, 4, 1))
+        end
+
+        it 'filters by entry_type' do
+          get api_v1_journal_journal_entries_path, params: { entry_type: 'weekly_reflection' }
+          expect(response.parsed_body.pluck('id')).to eq([weekly.id])
+        end
+
+        it 'filters by exact occurred_on' do
+          get api_v1_journal_journal_entries_path, params: { occurred_on: '2026-05-10' }
+          expect(response.parsed_body.pluck('id')).to eq([daily.id])
+        end
+
+        it 'filters by start_date (inclusive)' do
+          get api_v1_journal_journal_entries_path, params: { start_date: '2026-05-01' }
+          expect(response.parsed_body.pluck('id')).to contain_exactly(daily.id, weekly.id)
+        end
+
+        it 'filters by end_date (inclusive)' do
+          get api_v1_journal_journal_entries_path, params: { end_date: '2026-05-10' }
+          expect(response.parsed_body.pluck('id')).to contain_exactly(daily.id, general.id)
+        end
+
+        it 'combines start_date, end_date, and entry_type' do
+          get api_v1_journal_journal_entries_path,
+              params: { start_date: '2026-05-01', end_date: '2026-05-15', entry_type: 'daily_journal' }
+          expect(response.parsed_body.pluck('id')).to eq([daily.id])
+        end
+      end
+    end
+  end
+
+  describe 'GET /api/v1/journal/journal_entries/:id' do
+    let!(:entry) { create(:journal_entry, profile: profile, journal: journal) }
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        get api_v1_journal_journal_entry_path(entry)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'returns the entry with the expected fields' do
+        get api_v1_journal_journal_entry_path(entry)
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to include(
+          'id', 'journal_id', 'profile_id', 'title', 'body',
+          'entry_type', 'occurred_on', 'created_at', 'updated_at'
+        )
+        expect(json['id']).to eq(entry.id)
+      end
+
+      it 'returns 404 for an entry belonging to another profile' do
+        other_profile = create(:profile)
+        other_entry = create(:journal_entry, profile: other_profile, journal: create(:journal, profile: other_profile))
+
+        get api_v1_journal_journal_entry_path(other_entry)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'returns 404 for an entry that does not exist' do
+        get api_v1_journal_journal_entry_path(999_999)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/journal/journal_entries' do
+    let(:valid_params) do
+      {
+        journal_entry: {
+          title: 'Today',
+          body: 'Made progress on the journaling feature.',
+          entry_type: 'daily_journal',
+          occurred_on: '2026-05-21'
+        }
+      }
+    end
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        post api_v1_journal_journal_entries_path, params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'creates the entry under the profile and journal' do
+        expect { post api_v1_journal_journal_entries_path, params: valid_params }
+          .to change(JournalEntry, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['profile_id']).to eq(profile.id)
+        expect(json['journal_id']).to eq(journal.id)
+        expect(json['title']).to eq('Today')
+        expect(json['body']).to eq('Made progress on the journaling feature.')
+        expect(json['entry_type']).to eq('daily_journal')
+        expect(json['occurred_on']).to eq('2026-05-21')
+      end
+
+      it 'lazily creates the default journal if the profile has none' do
+        profile.journals.destroy_all
+
+        expect { post api_v1_journal_journal_entries_path, params: valid_params }
+          .to change { profile.journals.reload.count }.by(1)
+          .and change(JournalEntry, :count).by(1)
+
+        new_journal = profile.journals.first
+        expect(response.parsed_body['journal_id']).to eq(new_journal.id)
+      end
+
+      it 'defaults occurred_on to today when omitted' do
+        params = valid_params.deep_dup
+        params[:journal_entry].delete(:occurred_on)
+
+        post api_v1_journal_journal_entries_path, params: params
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['occurred_on']).to eq(Date.current.to_s)
+      end
+
+      it 'ignores client-supplied profile_id and journal_id' do
+        other_profile = create(:profile)
+        other_journal = create(:journal, profile: other_profile)
+        params = valid_params.deep_dup
+        params[:journal_entry][:profile_id] = other_profile.id
+        params[:journal_entry][:journal_id] = other_journal.id
+
+        post api_v1_journal_journal_entries_path, params: params
+
+        expect(response).to have_http_status(:created)
+        json = response.parsed_body
+        expect(json['profile_id']).to eq(profile.id)
+        expect(json['journal_id']).to eq(journal.id)
+      end
+
+      it 'returns 422 with errors when body is missing' do
+        params = { journal_entry: { entry_type: 'daily_journal' } }
+
+        expect { post api_v1_journal_journal_entries_path, params: params }
+          .not_to change(JournalEntry, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include("Body can't be blank")
+      end
+
+      it 'returns 422 for an unknown entry_type' do
+        params = { journal_entry: { body: 'x', entry_type: 'rant' } }
+
+        post api_v1_journal_journal_entries_path, params: params
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('Entry type is not included in the list')
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/journal/journal_entries/:id' do
+    let!(:entry) { create(:journal_entry, profile: profile, journal: journal, body: 'old') }
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        patch api_v1_journal_journal_entry_path(entry), params: { journal_entry: { body: 'new' } }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'updates the entry' do
+        patch api_v1_journal_journal_entry_path(entry), params: { journal_entry: { body: 'new body' } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body['body']).to eq('new body')
+        expect(entry.reload.body).to eq('new body')
+      end
+
+      it 'returns 422 with errors when body is set to blank' do
+        patch api_v1_journal_journal_entry_path(entry), params: { journal_entry: { body: '' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include("Body can't be blank")
+      end
+
+      it 'returns 422 for an unknown entry_type' do
+        patch api_v1_journal_journal_entry_path(entry), params: { journal_entry: { entry_type: 'rant' } }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body['errors']).to include('Entry type is not included in the list')
+      end
+
+      it 'returns 404 for an entry belonging to another profile' do
+        other_profile = create(:profile)
+        other_entry = create(:journal_entry, profile: other_profile, journal: create(:journal, profile: other_profile))
+
+        patch api_v1_journal_journal_entry_path(other_entry), params: { journal_entry: { body: 'hack' } }
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/journal/journal_entries/:id' do
+    let!(:entry) { create(:journal_entry, profile: profile, journal: journal) }
+
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        delete api_v1_journal_journal_entry_path(entry)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'deletes the entry and returns no content' do
+        expect { delete api_v1_journal_journal_entry_path(entry) }
+          .to change(JournalEntry, :count).by(-1)
+
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'returns 404 for an entry belonging to another profile' do
+        other_profile = create(:profile)
+        other_entry = create(:journal_entry, profile: other_profile, journal: create(:journal, profile: other_profile))
+
+        expect { delete api_v1_journal_journal_entry_path(other_entry) }
+          .not_to change(JournalEntry, :count)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/journals_controller_spec.rb
+++ b/spec/requests/api/v1/journals_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Journals', type: :request do
+  let!(:user) { create(:user) }
+  let!(:profile) { user.profile }
+
+  describe 'GET /api/v1/journal' do
+    context 'when unauthenticated' do
+      it 'returns unauthorized' do
+        get api_v1_journal_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when authenticated' do
+      before { sign_in user }
+
+      it 'returns the default journal with the expected fields' do
+        get api_v1_journal_path
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json).to include('id', 'title', 'description', 'kind', 'created_at', 'updated_at')
+        expect(json['kind']).to eq('default')
+        expect(json['title']).to eq(DefaultJournalFinder::DEFAULT_TITLE)
+        expect(json['description']).to eq(DefaultJournalFinder::DEFAULT_DESCRIPTION)
+      end
+
+      it 'lazily creates the default journal on first request' do
+        expect(profile.journals).to be_empty
+        expect { get api_v1_journal_path }.to change { profile.journals.reload.count }.by(1)
+      end
+
+      it 'returns the existing default journal without creating a duplicate' do
+        existing = create(:journal, profile: profile)
+
+        expect { get api_v1_journal_path }.not_to(change { profile.journals.reload.count })
+        expect(response.parsed_body['id']).to eq(existing.id)
+      end
+    end
+  end
+end

--- a/spec/services/journal_entries/create_spec.rb
+++ b/spec/services/journal_entries/create_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JournalEntries::Create do
+  describe '.call' do
+    let(:profile) { create(:profile) }
+
+    let(:valid_params) do
+      {
+        title: 'Today',
+        body: 'Made progress on the journaling feature.',
+        entry_type: 'daily_journal',
+        occurred_on: Date.new(2026, 5, 21)
+      }
+    end
+
+    context 'when the profile has no default journal yet' do
+      it 'creates the default journal and the entry' do
+        expect { described_class.call(profile: profile, params: valid_params) }
+          .to change(Journal, :count).by(1)
+          .and change(JournalEntry, :count).by(1)
+      end
+
+      it 'attaches the entry to the freshly created default journal' do
+        entry = described_class.call(profile: profile, params: valid_params)
+        expect(entry.journal).to eq(profile.journals.first)
+        expect(entry.profile).to eq(profile)
+      end
+    end
+
+    context 'when the profile already has a default journal' do
+      let!(:existing) { create(:journal, profile: profile) }
+
+      it 'reuses the existing journal' do
+        expect { described_class.call(profile: profile, params: valid_params) }
+          .to change(JournalEntry, :count).by(1)
+          .and not_change(Journal, :count)
+
+        expect(JournalEntry.last.journal).to eq(existing)
+      end
+    end
+
+    it 'defaults occurred_on to today when not supplied' do
+      params = valid_params.except(:occurred_on)
+      entry = described_class.call(profile: profile, params: params)
+      expect(entry.occurred_on).to eq(Date.current)
+    end
+
+    it 'defaults occurred_on to today when supplied as a blank string' do
+      params = valid_params.merge(occurred_on: '')
+      entry = described_class.call(profile: profile, params: params)
+      expect(entry.occurred_on).to eq(Date.current)
+    end
+
+    it 'returns an unpersisted entry with errors when validation fails' do
+      params = valid_params.merge(body: nil)
+      entry = described_class.call(profile: profile, params: params)
+
+      expect(entry).not_to be_persisted
+      expect(entry.errors[:body]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Implements PC-J2: the nested API for the current profile's default journal and its entries. Adds `GET /api/v1/journal` (returns the lazy-created default journal) plus full CRUD on `/api/v1/journal/journal_entries` with filters for `entry_type`, exact `occurred_on`, and `start_date`/`end_date` ranges. Introduces `JournalEntries::Create`, a service object that wraps `DefaultJournalFinder` + entry creation so the server (never the client) decides which journal an entry attaches to.

Authorization is enforced by scoping every action through `current_api_v1_profile`, which makes cross-profile reads/writes return 404. The controller permits only `:title, :body, :entry_type, :occurred_on` — any client-supplied `profile_id` / `journal_id` is silently ignored. `occurred_on` defaults to `Date.current` in the service when blank or missing.

### Why
This is the contract that PC-J3 (Journal Home + Entry Form) and PC-J4 (Entry Detail + filters) consume on the client. Pinning down routes, params, filters, and authorization here — with request-spec coverage — lets the RN tickets build against a stable surface instead of guessing.

## Changes
- `config/routes.rb`
  - Nested `resource :journal, only: %i[show]` with `resources :journal_entries, only: %i[index show create update destroy]` inside `api/v1`.
- `app/services/journal_entries/create.rb`
  - `JournalEntries::Create.call(profile:, params:)` — finds-or-creates the default journal via `DefaultJournalFinder`, then `create`s an entry assigned to that journal. Defaults `occurred_on` to `Date.current` when blank.
- `app/controllers/api/v1/journals_controller.rb`
  - `#show` returns the default journal (lazy creation via the finder). JSON includes `id`, `title`, `description`, `kind`, `created_at`, `updated_at`.
- `app/controllers/api/v1/journal_entries_controller.rb`
  - `#index` — scoped to `current_api_v1_profile.journal_entries`, ordered `occurred_on DESC, created_at DESC`. Filters (all optional, combinable): `entry_type`, `occurred_on`, `start_date`/`end_date` inclusive range.
  - `#show`, `#update`, `#destroy` — scoped to current profile; cross-profile entries 404.
  - `#create` — delegates to `JournalEntries::Create`; renders 201 on success, 422 with `errors` on validation failure.
  - Unknown `entry_type` values (e.g. `"rant"`) are rescued as `ArgumentError` and rendered as 422 — same pattern as `TasksController`.
  - Permitted params: `:title, :body, :entry_type, :occurred_on` only.
- `spec/rails_helper.rb`
  - `RSpec::Matchers.define_negated_matcher :not_change, :change` so compound expectations can use `change(...).and not_change(...)`.
- `spec/requests/api/v1/journals_controller_spec.rb`
  - 4 examples: unauthenticated → 401; happy path; lazy creation on first request; existing journal returned without duplicate.
- `spec/requests/api/v1/journal_entries_controller_spec.rb`
  - 28 examples covering: auth (one 401 per action), index scoping + ordering + each filter + filter combination, cross-profile 404s on show/update/destroy, create happy path, lazy default journal creation on first POST, default `occurred_on`, ignored client-supplied `profile_id`/`journal_id`, 422 on missing body, 422 on unknown `entry_type`, update happy + invalid, destroy happy + cross-profile.
- `spec/services/journal_entries/create_spec.rb`
  - 6 examples covering: journal lazy creation, reuse of existing default journal, default `occurred_on` (omitted and blank string), unpersisted entry returned with errors on validation failure.

## Test Plan
- [x] `bundle exec rspec spec/requests/api/v1/journals_controller_spec.rb spec/requests/api/v1/journal_entries_controller_spec.rb spec/services/journal_entries/create_spec.rb` — 38 examples, 0 failures.
- [x] `bundle exec rspec spec/models/ spec/services/ spec/requests/api/v1/` — 393 examples, 0 failures (full suite green, no regressions).
- [x] `bundle exec rubocop` on all 8 new/modified files — no offenses.
- [ ] Manual smoke after merge: `GET /api/v1/journal` returns 200, `POST /api/v1/journal/journal_entries` creates an entry, filter combinations return the expected subsets.

## Additional Notes
- Built on top of PC-J1 (PR #23, already merged). No further base-branch dependency.
- `#index` is **profile-scoped**, not journal-scoped — `current_api_v1_profile.journal_entries` rather than `DefaultJournalFinder.call(...).journal_entries`. Keeps reads free of writes (no `find_or_create_by` on every list call) and returns `[]` cleanly for users who have never journaled.
- The cross-profile invariant ("an entry's `profile_id` must match its `journal.profile_id`") continues to live at the controller/service layer rather than as a model validation — the service forces both values from the same `profile` argument, and the controller scopes finds through the profile.
- Out of scope: serializers / response shape changes (using `as_json` for parity with `TasksController`), AI-generated prompts, streak updates, goal associations — all deferred per the parent PC-J plan.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 260.29ms | ✅ |
| **90th Percentile Latency** | 244.79ms | - |
| **Average Latency** | 103.38ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 247.35ms | ✅ |
| **90th Percentile Latency** | 237.16ms | - |
| **Average Latency** | 92.87ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 250.31ms | ✅ |
| **90th Percentile Latency** | 233.46ms | - |
| **Average Latency** | 91.58ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 224.45ms | ✅ |
| **90th Percentile Latency** | 210.92ms | - |
| **Average Latency** | 87.17ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 654 requests, 436 checks passed, 218 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 246.59ms | ✅ |
| **90th Percentile Latency** | 240.31ms | - |
| **Average Latency** | 92.26ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1767.68ms | ✅ |
| **90th Percentile Latency** | 1630.20ms | - |
| **Average Latency** | 786.65ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 236.72ms | ✅ |
| **90th Percentile Latency** | 221.24ms | - |
| **Average Latency** | 84.47ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 657 requests, 657 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 262.56ms | ✅ |
| **90th Percentile Latency** | 253.45ms | - |
| **Average Latency** | 95.91ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 648 requests, 432 checks passed, 216 checks failed

---

<!-- PERF_RESULTS_END -->