### PR TITLE
feat: task and smart_goal due-date reminder notifications

### DIFF
--- a/app/controllers/api/v1/smart_goals_controller.rb
+++ b/app/controllers/api/v1/smart_goals_controller.rb
@@ -18,17 +18,20 @@ module Api
       end
 
       def create
-        smart_goal = current_api_v1_profile.smart_goals.build(smart_goal_params)
+        result = SmartGoals::Create.call(
+          profile: current_api_v1_profile,
+          params: create_smart_goal_params
+        )
 
-        if smart_goal.save
-          render json: smart_goal, status: :created
+        if result.success?
+          render json: result.smart_goal, status: :created
         else
-          render json: { errors: smart_goal.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: result.errors }, status: :unprocessable_entity
         end
       end
 
       def update
-        if @smart_goal.update(smart_goal_params)
+        if @smart_goal.update(update_smart_goal_params)
           render json: @smart_goal
         else
           render json: { errors: @smart_goal.errors.full_messages }, status: :unprocessable_entity
@@ -42,10 +45,17 @@ module Api
 
       private
 
-      def smart_goal_params
+      def create_smart_goal_params
         params.require(:smart_goal).permit(
           :title, :description, :timeframe, :specific, :measurable,
-          :achievable, :relevant, :time_bound, :completed, :target_date
+          :achievable, :relevant, :time_bound, :completed
+        )
+      end
+
+      def update_smart_goal_params
+        params.require(:smart_goal).permit(
+          :title, :description, :timeframe, :specific, :measurable,
+          :achievable, :relevant, :time_bound, :completed
         )
       end
 

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -58,7 +58,7 @@ module Api
 
       def task_params
         params.require(:task).permit(
-          :title, :description, :completed, :action_category, :priority, :smart_goal_id, :due_at
+          :title, :description, :completed, :action_category, :priority, :smart_goal_id, :due_at, :reminder_at
         )
       end
     end

--- a/app/jobs/notifications/schedule_smart_goal_reminders_job.rb
+++ b/app/jobs/notifications/schedule_smart_goal_reminders_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Notifications::ScheduleSmartGoalRemindersJob < ApplicationJob
+  queue_as :critical
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform
+    eligible_profiles.find_each do |profile|
+      tz = ActiveSupport::TimeZone[profile.timezone]
+      next unless tz
+
+      now_local = Time.current.in_time_zone(tz)
+      day_start_utc = now_local.beginning_of_day.utc
+      day_end_utc = now_local.end_of_day.utc
+      current_hour = now_local.hour
+
+      already_notified = already_notified_smart_goal_ids(profile, day_start_utc, day_end_utc)
+
+      smart_goals_due_today(profile, day_start_utc, day_end_utc, current_hour).find_each do |smart_goal|
+        next if already_notified.include?(smart_goal.id)
+
+        Notifications::SmartGoalReminderJob.perform_later(smart_goal.id)
+      end
+    end
+  end
+
+  private
+
+  def eligible_profiles
+    Profile.push_notification_eligible
+  end
+
+  def smart_goals_due_today(profile, day_start_utc, day_end_utc, current_hour)
+    profile.smart_goals
+           .where(completed: false)
+           .where(target_date: day_start_utc..day_end_utc)
+           .where('EXTRACT(HOUR FROM reminder_at) <= ?', current_hour)
+  end
+
+  def already_notified_smart_goal_ids(profile, day_start_utc, day_end_utc)
+    profile.notifications
+           .where(notification_type: 'smart_goal_reminder')
+           .where(scheduled_for: day_start_utc..day_end_utc)
+           .pluck(Arel.sql("data->>'smart_goal_id'"))
+           .compact
+           .to_set(&:to_i)
+  end
+end

--- a/app/jobs/notifications/schedule_task_reminders_job.rb
+++ b/app/jobs/notifications/schedule_task_reminders_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Notifications::ScheduleTaskRemindersJob < ApplicationJob
+  queue_as :critical
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform
+    eligible_profiles.find_each do |profile|
+      tz = ActiveSupport::TimeZone[profile.timezone]
+      next unless tz
+
+      now_local = Time.current.in_time_zone(tz)
+      day_start_utc = now_local.beginning_of_day.utc
+      day_end_utc = now_local.end_of_day.utc
+      current_hour = now_local.hour
+
+      already_notified = already_notified_task_ids(profile, day_start_utc, day_end_utc)
+
+      tasks_due_today(profile, day_start_utc, day_end_utc, current_hour).find_each do |task|
+        next if already_notified.include?(task.id)
+
+        Notifications::TaskReminderJob.perform_later(task.id)
+      end
+    end
+  end
+
+  private
+
+  def eligible_profiles
+    Profile.push_notification_eligible
+  end
+
+  def tasks_due_today(profile, day_start_utc, day_end_utc, current_hour)
+    profile.tasks
+           .where(completed: false)
+           .where(due_at: day_start_utc..day_end_utc)
+           .where('EXTRACT(HOUR FROM reminder_at) <= ?', current_hour)
+  end
+
+  def already_notified_task_ids(profile, day_start_utc, day_end_utc)
+    profile.notifications
+           .where(notification_type: 'task_reminder')
+           .where(scheduled_for: day_start_utc..day_end_utc)
+           .pluck(Arel.sql("data->>'task_id'"))
+           .compact
+           .to_set(&:to_i)
+  end
+end

--- a/app/jobs/notifications/smart_goal_reminder_job.rb
+++ b/app/jobs/notifications/smart_goal_reminder_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Notifications::SmartGoalReminderJob < ApplicationJob
+  queue_as :notifications
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform(smart_goal_id)
+    smart_goal = SmartGoal.find(smart_goal_id)
+    return if smart_goal.completed?
+
+    Notifications::SmartGoalReminderService.new(smart_goal.profile, smart_goal: smart_goal).call
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("SmartGoalReminderJob: SmartGoal not found: #{smart_goal_id}")
+  end
+end

--- a/app/jobs/notifications/task_reminder_job.rb
+++ b/app/jobs/notifications/task_reminder_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Notifications::TaskReminderJob < ApplicationJob
+  queue_as :notifications
+
+  retry_on StandardError, wait: :polynomially_longer, attempts: 2
+
+  def perform(task_id)
+    task = Task.find(task_id)
+    return if task.completed?
+
+    Notifications::TaskReminderService.new(task.profile, task: task).call
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.warn("TaskReminderJob: Task not found: #{task_id}")
+  end
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,7 +4,7 @@ class Notification < ApplicationRecord
   belongs_to :profile
   belongs_to :device_token, optional: true # For push, tracks which device
 
-  TYPES = %w[daily_reminder engagement_reminder task_reminder].freeze
+  TYPES = %w[daily_reminder engagement_reminder task_reminder smart_goal_reminder].freeze
   STATUSES = %w[pending sent failed].freeze
   CHANNELS = %w[push email sms].freeze
 

--- a/app/models/smart_goal.rb
+++ b/app/models/smart_goal.rb
@@ -11,6 +11,7 @@ class SmartGoal < ApplicationRecord
   validates :achievable, presence: true
   validates :relevant, presence: true
   validates :time_bound, presence: true
+  validates :target_date, presence: true
 
   scope :by_timeframe, ->(timeframe) { where(timeframe: timeframe) }
   scope :completed, -> { where(completed: true) }

--- a/app/services/smart_goals/create.rb
+++ b/app/services/smart_goals/create.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SmartGoals
+  # Creates a SmartGoal with a server-derived target_date computed from
+  # the chosen timeframe and the profile's timezone. Centralizes the
+  # "the server owns target_date" rule so controllers never accept a
+  # client-supplied value.
+  class Create
+    TIMEFRAME_TO_MONTHS = {
+      '1_month' => 1,
+      '3_months' => 3,
+      '6_months' => 6
+    }.freeze
+
+    Result = Struct.new(:smart_goal, :errors, keyword_init: true) do
+      def success?
+        errors.empty?
+      end
+    end
+
+    def self.call(profile:, params:)
+      new(profile: profile, params: params).call
+    end
+
+    def initialize(profile:, params:)
+      @profile = profile
+      @params = params
+    end
+
+    def call
+      smart_goal = @profile.smart_goals.build(@params.merge(target_date: derived_target_date))
+      smart_goal.save
+      Result.new(smart_goal: smart_goal, errors: smart_goal.errors.full_messages)
+    end
+
+    private
+
+    def derived_target_date
+      months = TIMEFRAME_TO_MONTHS[@params[:timeframe]]
+      return nil unless months
+
+      Time.current.in_time_zone(@profile.timezone).beginning_of_day + months.months
+    end
+  end
+end

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -11,3 +11,17 @@ schedule_engagement_reminders:
   queue: critical
   active_job: true
   description: "Send engagement reminders to users inactive for 3+ days"
+
+schedule_task_reminders:
+  cron: "0 * * * *"
+  class: "Notifications::ScheduleTaskRemindersJob"
+  queue: critical
+  active_job: true
+  description: "Schedule task due-date reminders based on each task's reminder_at hour"
+
+schedule_smart_goal_reminders:
+  cron: "0 * * * *"
+  class: "Notifications::ScheduleSmartGoalRemindersJob"
+  queue: critical
+  active_job: true
+  description: "Schedule smart goal target-date reminders based on each goal's reminder_at hour"

--- a/db/migrate/20260525120000_add_reminder_at_to_tasks.rb
+++ b/db/migrate/20260525120000_add_reminder_at_to_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReminderAtToTasks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tasks, :reminder_at, :time, null: false, default: '09:00:00'
+  end
+end

--- a/db/migrate/20260525120001_add_reminder_at_to_smart_goals.rb
+++ b/db/migrate/20260525120001_add_reminder_at_to_smart_goals.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReminderAtToSmartGoals < ActiveRecord::Migration[7.2]
+  def change
+    add_column :smart_goals, :reminder_at, :time, null: false, default: '09:00:00'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_120100) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_25_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -141,6 +141,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_120100) do
     t.datetime "target_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.time "reminder_at", default: "2000-01-01 09:00:00", null: false
     t.index ["profile_id"], name: "index_smart_goals_on_profile_id"
   end
 
@@ -155,6 +156,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_120100) do
     t.integer "priority"
     t.bigint "smart_goal_id"
     t.datetime "due_at"
+    t.time "reminder_at", default: "2000-01-01 09:00:00", null: false
     t.index ["profile_id"], name: "index_tasks_on_profile_id"
     t.index ["smart_goal_id"], name: "index_tasks_on_smart_goal_id"
   end

--- a/lib/notifications/smart_goal_reminder_service.rb
+++ b/lib/notifications/smart_goal_reminder_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Notifications
+  class SmartGoalReminderService < BaseService
+    def initialize(profile, smart_goal:, channels: nil)
+      super(profile, channels: channels)
+      @smart_goal = smart_goal
+    end
+
+    def notification_type
+      'smart_goal_reminder'
+    end
+
+    def notification_title
+      'Goal target date today 🎯'
+    end
+
+    def notification_body
+      @smart_goal.title
+    end
+
+    def notification_data
+      {
+        type: 'smart_goal_reminder',
+        screen: 'smartGoalDetail',
+        smart_goal_id: @smart_goal.id
+      }
+    end
+  end
+end

--- a/lib/notifications/task_reminder_service.rb
+++ b/lib/notifications/task_reminder_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Notifications
+  class TaskReminderService < BaseService
+    def initialize(profile, task:, channels: nil)
+      super(profile, channels: channels)
+      @task = task
+    end
+
+    def notification_type
+      'task_reminder'
+    end
+
+    def notification_title
+      'Task due today 📌'
+    end
+
+    def notification_body
+      @task.title
+    end
+
+    def notification_data
+      {
+        type: 'task_reminder',
+        screen: 'taskDetail',
+        task_id: @task.id
+      }
+    end
+  end
+end

--- a/spec/jobs/notifications/schedule_smart_goal_reminders_job_spec.rb
+++ b/spec/jobs/notifications/schedule_smart_goal_reminders_job_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::ScheduleSmartGoalRemindersJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before do
+    Sidekiq::Testing.fake!
+    Sidekiq::Queues.clear_all
+    travel_to Time.zone.local(2026, 5, 25, 10, 0, 0)
+  end
+
+  let(:profile) do
+    profile = create(:profile, timezone: 'UTC')
+    profile.notification_preference.update!(push_enabled: true)
+    create(:device_token, profile: profile, active: true)
+    profile
+  end
+
+  describe '#perform' do
+    context 'when a smart goal target_date is today and reminder hour has been reached' do
+      it 'enqueues a SmartGoalReminderJob for the goal' do
+        goal = create(:smart_goal, profile: profile, completed: false,
+                                   target_date: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                                   reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(Notifications::SmartGoalReminderJob).with(goal.id)
+      end
+    end
+
+    context "when the goal's reminder hour has not been reached yet" do
+      it 'does not enqueue a SmartGoalReminderJob' do
+        create(:smart_goal, profile: profile, completed: false,
+                            target_date: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                            reminder_at: '14:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::SmartGoalReminderJob)
+      end
+    end
+
+    context 'when the goal is completed' do
+      it 'does not enqueue a SmartGoalReminderJob' do
+        create(:smart_goal, profile: profile, completed: true,
+                            target_date: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                            reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::SmartGoalReminderJob)
+      end
+    end
+
+    context "when the goal's target_date is tomorrow" do
+      it 'does not enqueue a SmartGoalReminderJob' do
+        create(:smart_goal, profile: profile, completed: false,
+                            target_date: Time.zone.local(2026, 5, 26, 12, 0, 0),
+                            reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::SmartGoalReminderJob)
+      end
+    end
+
+    context 'when a smart_goal_reminder has already been sent for this goal today' do
+      it 'does not enqueue a SmartGoalReminderJob' do
+        goal = create(:smart_goal, profile: profile, completed: false,
+                                   target_date: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                                   reminder_at: '09:00:00')
+        Notification.create!(
+          profile: profile,
+          notification_type: 'smart_goal_reminder',
+          channel: 'push',
+          title: 'Goal target date today 🎯',
+          body: goal.title,
+          data: { smart_goal_id: goal.id },
+          status: 'sent',
+          scheduled_for: Time.zone.local(2026, 5, 25, 9, 0, 0)
+        )
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::SmartGoalReminderJob)
+      end
+    end
+
+    context 'when the profile is not push-eligible' do
+      it 'does not enqueue a SmartGoalReminderJob' do
+        ineligible = create(:profile, timezone: 'UTC')
+        ineligible.notification_preference.update!(push_enabled: false)
+        create(:smart_goal, profile: ineligible, completed: false,
+                            target_date: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                            reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::SmartGoalReminderJob)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the critical queue' do
+      expect(described_class.queue_name).to eq('critical')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/schedule_task_reminders_job_spec.rb
+++ b/spec/jobs/notifications/schedule_task_reminders_job_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::ScheduleTaskRemindersJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  before do
+    Sidekiq::Testing.fake!
+    Sidekiq::Queues.clear_all
+    travel_to Time.zone.local(2026, 5, 25, 10, 0, 0) # 10:00 UTC on a fixed date
+  end
+
+  let(:profile) do
+    profile = create(:profile, timezone: 'UTC')
+    profile.notification_preference.update!(push_enabled: true)
+    create(:device_token, profile: profile, active: true)
+    profile
+  end
+
+  describe '#perform' do
+    context 'when a task is due today and reminder hour has been reached' do
+      it 'enqueues a TaskReminderJob for the task' do
+        task = create(:task, profile: profile, completed: false,
+                             due_at: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                             reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(Notifications::TaskReminderJob).with(task.id)
+      end
+    end
+
+    context "when the task's reminder hour has not been reached yet" do
+      it 'does not enqueue a TaskReminderJob' do
+        create(:task, profile: profile, completed: false,
+                      due_at: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                      reminder_at: '14:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'when the task is completed' do
+      it 'does not enqueue a TaskReminderJob' do
+        create(:task, profile: profile, completed: true,
+                      due_at: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                      reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'when the task is due tomorrow' do
+      it 'does not enqueue a TaskReminderJob' do
+        create(:task, profile: profile, completed: false,
+                      due_at: Time.zone.local(2026, 5, 26, 12, 0, 0),
+                      reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'when the task is overdue (due yesterday)' do
+      it 'does not enqueue a TaskReminderJob' do
+        create(:task, profile: profile, completed: false,
+                      due_at: Time.zone.local(2026, 5, 24, 12, 0, 0),
+                      reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'when a task_reminder has already been sent for this task today' do
+      it 'does not enqueue a TaskReminderJob' do
+        task = create(:task, profile: profile, completed: false,
+                             due_at: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                             reminder_at: '09:00:00')
+        Notification.create!(
+          profile: profile,
+          notification_type: 'task_reminder',
+          channel: 'push',
+          title: 'Task due today 📌',
+          body: task.title,
+          data: { task_id: task.id },
+          status: 'sent',
+          scheduled_for: Time.zone.local(2026, 5, 25, 9, 0, 0)
+        )
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'when the profile is not push-eligible' do
+      it 'does not enqueue a TaskReminderJob' do
+        ineligible = create(:profile, timezone: 'UTC')
+        ineligible.notification_preference.update!(push_enabled: false)
+        create(:task, profile: ineligible, completed: false,
+                      due_at: Time.zone.local(2026, 5, 25, 15, 0, 0),
+                      reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.not_to have_enqueued_job(Notifications::TaskReminderJob)
+      end
+    end
+
+    context 'with multiple due tasks for one profile' do
+      it 'enqueues a job for each task' do
+        create(:task, profile: profile, completed: false,
+                      due_at: Time.zone.local(2026, 5, 25, 12, 0, 0),
+                      reminder_at: '09:00:00')
+        create(:task, profile: profile, completed: false,
+                      due_at: Time.zone.local(2026, 5, 25, 18, 0, 0),
+                      reminder_at: '09:00:00')
+
+        expect do
+          described_class.perform_now
+        end.to have_enqueued_job(Notifications::TaskReminderJob).exactly(2).times
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the critical queue' do
+      expect(described_class.queue_name).to eq('critical')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/smart_goal_reminder_job_spec.rb
+++ b/spec/jobs/notifications/smart_goal_reminder_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::SmartGoalReminderJob, type: :job do
+  let(:profile) { create(:profile) }
+  let(:smart_goal) { create(:smart_goal, profile: profile) }
+
+  before do
+    Sidekiq::Testing.inline!
+    allow(Rails.logger).to receive(:warn)
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  describe '#perform' do
+    context 'when the smart goal exists and is not completed' do
+      it 'calls SmartGoalReminderService with the profile and smart goal' do
+        mock_service = instance_double(Notifications::SmartGoalReminderService)
+        allow(Notifications::SmartGoalReminderService).to receive(:new)
+          .with(profile, smart_goal: smart_goal)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now(smart_goal.id)
+
+        expect(Notifications::SmartGoalReminderService).to have_received(:new).with(profile, smart_goal: smart_goal)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'when the smart goal is already completed' do
+      it 'does not call the service' do
+        smart_goal.update!(completed: true)
+        allow(Notifications::SmartGoalReminderService).to receive(:new)
+
+        described_class.perform_now(smart_goal.id)
+
+        expect(Notifications::SmartGoalReminderService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the smart goal is not found' do
+      it 'logs a warning and does not raise' do
+        expect do
+          described_class.perform_now(999_999)
+        end.not_to raise_error
+
+        expect(Rails.logger).to have_received(:warn)
+          .with(/SmartGoalReminderJob: SmartGoal not found: 999999/)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the notifications queue' do
+      expect(described_class.queue_name).to eq('notifications')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/jobs/notifications/task_reminder_job_spec.rb
+++ b/spec/jobs/notifications/task_reminder_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'sidekiq/testing'
+
+RSpec.describe Notifications::TaskReminderJob, type: :job do
+  let(:profile) { create(:profile) }
+  let(:task) { create(:task, profile: profile) }
+
+  before do
+    Sidekiq::Testing.inline!
+    allow(Rails.logger).to receive(:warn)
+  end
+
+  after do
+    Sidekiq::Testing.fake!
+  end
+
+  describe '#perform' do
+    context 'when the task exists and is not completed' do
+      it 'calls TaskReminderService with the profile and task' do
+        mock_service = instance_double(Notifications::TaskReminderService)
+        allow(Notifications::TaskReminderService).to receive(:new)
+          .with(profile, task: task)
+          .and_return(mock_service)
+        allow(mock_service).to receive(:call)
+
+        described_class.perform_now(task.id)
+
+        expect(Notifications::TaskReminderService).to have_received(:new).with(profile, task: task)
+        expect(mock_service).to have_received(:call)
+      end
+    end
+
+    context 'when the task is already completed' do
+      it 'does not call the service' do
+        task.update!(completed: true)
+        allow(Notifications::TaskReminderService).to receive(:new)
+
+        described_class.perform_now(task.id)
+
+        expect(Notifications::TaskReminderService).not_to have_received(:new)
+      end
+    end
+
+    context 'when the task is not found' do
+      it 'logs a warning and does not raise' do
+        expect do
+          described_class.perform_now(999_999)
+        end.not_to raise_error
+
+        expect(Rails.logger).to have_received(:warn)
+          .with(/TaskReminderJob: Task not found: 999999/)
+      end
+    end
+  end
+
+  describe 'queue configuration' do
+    it 'uses the notifications queue' do
+      expect(described_class.queue_name).to eq('notifications')
+    end
+
+    it 'has retry configuration' do
+      expect(described_class).to respond_to(:retry_on)
+    end
+  end
+end

--- a/spec/lib/notifications/smart_goal_reminder_service_spec.rb
+++ b/spec/lib/notifications/smart_goal_reminder_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::SmartGoalReminderService do
+  subject(:service) { described_class.new(profile, smart_goal: smart_goal) }
+
+  let(:profile) { create(:profile) }
+  let(:smart_goal) { create(:smart_goal, profile: profile, title: 'Run a marathon') }
+
+  describe '#notification_type' do
+    it 'returns smart_goal_reminder' do
+      expect(service.notification_type).to eq('smart_goal_reminder')
+    end
+  end
+
+  describe '#notification_title' do
+    it 'returns a generic target-date title' do
+      expect(service.notification_title).to eq('Goal target date today 🎯')
+    end
+  end
+
+  describe '#notification_body' do
+    it 'returns the smart goal title' do
+      expect(service.notification_body).to eq('Run a marathon')
+    end
+  end
+
+  describe '#notification_data' do
+    it 'includes the smart_goal_id and routing metadata' do
+      expect(service.notification_data).to eq({
+                                                type: 'smart_goal_reminder',
+                                                screen: 'smartGoalDetail',
+                                                smart_goal_id: smart_goal.id
+                                              })
+    end
+  end
+end

--- a/spec/lib/notifications/task_reminder_service_spec.rb
+++ b/spec/lib/notifications/task_reminder_service_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::TaskReminderService do
+  subject(:service) { described_class.new(profile, task: task) }
+
+  let(:profile) { create(:profile) }
+  let(:task) { create(:task, profile: profile, title: 'Submit Q2 report') }
+
+  describe '#notification_type' do
+    it 'returns task_reminder' do
+      expect(service.notification_type).to eq('task_reminder')
+    end
+  end
+
+  describe '#notification_title' do
+    it 'returns a generic due-today title' do
+      expect(service.notification_title).to eq('Task due today 📌')
+    end
+  end
+
+  describe '#notification_body' do
+    it 'returns the task title' do
+      expect(service.notification_body).to eq('Submit Q2 report')
+    end
+  end
+
+  describe '#notification_data' do
+    it 'includes the task_id and routing metadata' do
+      expect(service.notification_data).to eq({
+                                                type: 'task_reminder',
+                                                screen: 'taskDetail',
+                                                task_id: task.id
+                                              })
+    end
+  end
+end

--- a/spec/models/smart_goal_spec.rb
+++ b/spec/models/smart_goal_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmartGoal, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:profile) }
+    it { is_expected.to have_many(:tasks).dependent(:nullify) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:specific) }
+    it { is_expected.to validate_presence_of(:measurable) }
+    it { is_expected.to validate_presence_of(:achievable) }
+    it { is_expected.to validate_presence_of(:relevant) }
+    it { is_expected.to validate_presence_of(:time_bound) }
+    it { is_expected.to validate_presence_of(:target_date) }
+    it { is_expected.to validate_inclusion_of(:timeframe).in_array(%w[1_month 3_months 6_months]) }
+  end
+end

--- a/spec/requests/api/v1/smart_goals_controller_spec.rb
+++ b/spec/requests/api/v1/smart_goals_controller_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::SmartGoals', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let!(:user) { create(:user) }
   let!(:profile) { user.profile }
 
@@ -173,8 +175,7 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
             achievable: 'Dedicate 2 hours daily to learning and practice',
             relevant: 'Enhance mobile development skills for career growth',
             time_bound: 'Complete all projects within 3 months',
-            completed: false,
-            target_date: 3.months.from_now.to_date
+            completed: false
           }
         }
       end
@@ -204,6 +205,29 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
           expect(json_response['completed']).to be(false)
         end
       end
+
+      it 'derives target_date from timeframe in the profile timezone' do
+        profile.update!(timezone: 'America/Los_Angeles')
+
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          post api_v1_smart_goals_path, params: valid_params
+
+          expected = Time.current.in_time_zone('America/Los_Angeles').beginning_of_day + 3.months
+          expect(Time.zone.parse(response.parsed_body['target_date'])).to eq(expected)
+        end
+      end
+
+      it 'ignores any client-supplied target_date and derives its own' do
+        bogus = 10.years.from_now.to_date.iso8601
+        params_with_target = valid_params.deep_merge(smart_goal: { target_date: bogus })
+
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          post api_v1_smart_goals_path, params: params_with_target
+
+          expected = Time.current.in_time_zone(profile.timezone).beginning_of_day + 3.months
+          expect(Time.zone.parse(response.parsed_body['target_date'])).to eq(expected)
+        end
+      end
     end
 
     context 'with invalid parameters' do
@@ -218,8 +242,7 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
               achievable: 'Dedicate 2 hours daily to learning and practice',
               relevant: 'Enhance mobile development skills for career growth',
               time_bound: 'Complete all projects within 3 months',
-              completed: false,
-              target_date: 3.months.from_now.to_date
+              completed: false
             }
           }
         end
@@ -256,8 +279,7 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
               achievable: 'Dedicate 2 hours daily to learning and practice',
               relevant: 'Enhance mobile development skills for career growth',
               time_bound: 'Complete all projects within 3 months',
-              completed: false,
-              target_date: 3.months.from_now.to_date
+              completed: false
             }
           }
         end
@@ -287,8 +309,7 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
               achievable: 'Dedicate 2 hours daily to learning and practice',
               relevant: 'Enhance mobile development skills for career growth',
               time_bound: 'Complete all projects within 3 months',
-              completed: false,
-              target_date: 3.months.from_now.to_date
+              completed: false
             }
           }
         end

--- a/spec/services/smart_goals/create_spec.rb
+++ b/spec/services/smart_goals/create_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmartGoals::Create do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:profile) { create(:profile, timezone: 'America/Los_Angeles') }
+
+  let(:valid_params) do
+    {
+      title: 'Learn React Native',
+      description: 'Master React Native development',
+      timeframe: '3_months',
+      specific: 'Ship 3 RN apps',
+      measurable: 'Three deployed apps',
+      achievable: '2h/day',
+      relevant: 'Career growth',
+      time_bound: 'Three months',
+      completed: false
+    }
+  end
+
+  describe '.call' do
+    context 'with valid params and timeframe 1_month' do
+      let(:params) { valid_params.merge(timeframe: '1_month') }
+
+      it 'persists the smart goal and returns a successful result' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: params)
+
+          expect(result).to be_success
+          expect(result.smart_goal).to be_persisted
+          expect(result.errors).to be_empty
+        end
+      end
+
+      it 'derives target_date as start-of-day in profile TZ + 1 month' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: params)
+
+          expected = Time.current.in_time_zone('America/Los_Angeles').beginning_of_day + 1.month
+          expect(result.smart_goal.target_date).to eq(expected)
+        end
+      end
+    end
+
+    context 'with timeframe 3_months' do
+      it 'derives target_date 3 months ahead' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: valid_params)
+
+          expected = Time.current.in_time_zone('America/Los_Angeles').beginning_of_day + 3.months
+          expect(result.smart_goal.target_date).to eq(expected)
+        end
+      end
+    end
+
+    context 'with timeframe 6_months' do
+      let(:params) { valid_params.merge(timeframe: '6_months') }
+
+      it 'derives target_date 6 months ahead' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: params)
+
+          expected = Time.current.in_time_zone('America/Los_Angeles').beginning_of_day + 6.months
+          expect(result.smart_goal.target_date).to eq(expected)
+        end
+      end
+    end
+
+    context 'when the profile timezone is not UTC' do
+      let(:profile) { create(:profile, timezone: 'Asia/Tokyo') }
+
+      it 'anchors target_date to start-of-day in the profile timezone' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: valid_params)
+
+          expected = Time.current.in_time_zone('Asia/Tokyo').beginning_of_day + 3.months
+          expect(result.smart_goal.target_date).to eq(expected)
+        end
+      end
+    end
+
+    context 'when target_date is supplied by the caller' do
+      let(:params) { valid_params.merge(target_date: 10.years.from_now) }
+
+      it 'ignores the caller-supplied target_date and derives its own' do
+        travel_to Time.zone.local(2026, 5, 25, 14, 30, 0) do
+          result = described_class.call(profile: profile, params: params)
+
+          expected = Time.current.in_time_zone('America/Los_Angeles').beginning_of_day + 3.months
+          expect(result.smart_goal.target_date).to eq(expected)
+        end
+      end
+    end
+
+    context 'with an unknown timeframe' do
+      let(:params) { valid_params.merge(timeframe: 'invalid_timeframe') }
+
+      it 'returns an unsuccessful result with timeframe and target_date errors' do
+        result = described_class.call(profile: profile, params: params)
+
+        expect(result).not_to be_success
+        expect(result.smart_goal).not_to be_persisted
+        expect(result.errors).to include('Timeframe is not included in the list')
+        expect(result.errors).to include("Target date can't be blank")
+      end
+    end
+
+    context 'when a required field is missing' do
+      let(:params) { valid_params.except(:specific) }
+
+      it 'returns an unsuccessful result with the model error' do
+        result = described_class.call(profile: profile, params: params)
+
+        expect(result).not_to be_success
+        expect(result.smart_goal).not_to be_persisted
+        expect(result.errors).to include("Specific can't be blank")
+      end
+    end
+
+    it 'associates the goal with the given profile' do
+      result = described_class.call(profile: profile, params: valid_params)
+
+      expect(result.smart_goal.profile).to eq(profile)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR delivers due-date push reminders for both tasks and smart goals via hourly schedulers and per-record jobs.  
It also makes SmartGoal `target_date` server-owned by deriving it from `timeframe` during creation, improving reminder reliability for newly created goals.

## Why

`task_reminder` existed but wasn’t wired end-to-end, causing silent misses.  
SmartGoal reminders depend on `target_date`, but create flows could leave it unset or client-controlled. This PR closes both gaps.

## Changes

### Reminder pipeline

- Added `reminder_at` columns with default `09:00:00`:
  - `tasks.reminder_at`
  - `smart_goals.reminder_at`
- Added `smart_goal_reminder` notification type.
- Added reminder services:
  - `Notifications::TaskReminderService`
  - `Notifications::SmartGoalReminderService`
- Added per-record jobs:
  - `Notifications::TaskReminderJob`
  - `Notifications::SmartGoalReminderJob`
- Added hourly schedulers:
  - `Notifications::ScheduleTaskRemindersJob`
  - `Notifications::ScheduleSmartGoalRemindersJob`
- Registered cron entries in `config/sidekiq_cron.yml` on `0 * * * *`.
- Permitted `tasks.reminder_at` in task params.

### SmartGoal create hardening

- Added `SmartGoals::Create` service to centralize SmartGoal creation.
- `SmartGoalsController#create` now delegates to service.
- Removed client control of `target_date` from SmartGoal params.
- Added `SmartGoal` validation for `target_date` presence.
- `target_date` is derived from `timeframe` in profile timezone.

### Tests

- Added/updated coverage for:
  - reminder services
  - reminder jobs
  - scheduler jobs
  - SmartGoal creation service
  - SmartGoal model validation
  - SmartGoal request behavior (derived `target_date`, ignore client value)

## Testing

- `bundle exec rspec`
- `bundle exec rubocop`
- `bundle exec rails db:migrate` (dev + test)
- Post-merge:
  - verify scheduler entries in Sidekiq Cron
  - verify day-of task reminder sends
  - verify day-of smart-goal reminder sends
  - verify SmartGoal create returns server-derived `target_date`

## Risk / Notes

- Dedupe is day-scoped via existing notification rows (`task_id`/`smart_goal_id` in `data`).
- Failed sends still count as attempted for that day.
- `smart_goals.reminder_at` remains server-managed for now.
- New behavior: SmartGoal `target_date` is no longer client-controlled.

## Follow-ups

- Backfill existing SmartGoals with null `target_date`.
- Add DB `NOT NULL` constraint for `smart_goals.target_date` after backfill.
- Decide whether changing `timeframe` should recalculate `target_date`.
- Move PC-E in Trello manually if Composio access remains unavailable.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 265.54ms | ✅ |
| **90th Percentile Latency** | 248.03ms | - |
| **Average Latency** | 100.15ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 636 requests, 636 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 245.94ms | ✅ |
| **90th Percentile Latency** | 240.63ms | - |
| **Average Latency** | 94.79ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 241.69ms | ✅ |
| **90th Percentile Latency** | 234.44ms | - |
| **Average Latency** | 91.38ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 645 requests, 645 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 218.84ms | ✅ |
| **90th Percentile Latency** | 205.30ms | - |
| **Average Latency** | 82.72ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 657 requests, 438 checks passed, 219 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 248.68ms | ✅ |
| **90th Percentile Latency** | 240.31ms | - |
| **Average Latency** | 96.80ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1870.76ms | ✅ |
| **90th Percentile Latency** | 1643.88ms | - |
| **Average Latency** | 808.82ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 226.61ms | ✅ |
| **90th Percentile Latency** | 211.14ms | - |
| **Average Latency** | 85.46ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 657 requests, 657 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 271.92ms | ✅ |
| **90th Percentile Latency** | 258.30ms | - |
| **Average Latency** | 99.52ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 639 requests, 426 checks passed, 213 checks failed

---

<!-- PERF_RESULTS_END -->