### PR TITLE
feat/adds smart goal target date backfill rake task

### DIFF
--- a/lib/tasks/smart_goals/backfill_target_dates.rake
+++ b/lib/tasks/smart_goals/backfill_target_dates.rake
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+
+namespace :smart_goals do
+  desc 'Backfill null smart_goals.target_date from timeframe and profile timezone'
+  task backfill_target_dates: :environment do
+    batch_size = ENV.fetch('BATCH_SIZE', '500').to_i
+    dry_run = ActiveModel::Type::Boolean.new.cast(ENV.fetch('DRY_RUN', 'false'))
+    report_path = ENV['REPORT_PATH'].presence || default_report_path
+
+    scope = SmartGoal.where(target_date: nil).includes(:profile)
+    total = scope.count
+
+    puts "Starting smart goal target_date backfill (rows: #{total}, batch_size: #{batch_size}, dry_run: #{dry_run})"
+    next puts 'No rows to backfill.' if total.zero?
+
+    stats = {
+      scanned: 0,
+      updated: 0,
+      failed: 0
+    }
+    failures = []
+
+    scope.find_in_batches(batch_size: batch_size) do |batch|
+      batch.each do |smart_goal|
+        stats[:scanned] += 1
+
+        target_date_or_error = derive_target_date(smart_goal)
+        if target_date_or_error[:error]
+          stats[:failed] += 1
+          failures << failure_payload(smart_goal, target_date_or_error[:error])
+          next
+        end
+
+        if dry_run
+          stats[:updated] += 1
+          next
+        end
+
+        begin
+          smart_goal.update_columns(target_date: target_date_or_error[:target_date], updated_at: Time.current)
+          stats[:updated] += 1
+        rescue StandardError => e
+          stats[:failed] += 1
+          failures << failure_payload(smart_goal, "failed_to_persist: #{e.message}")
+        end
+      end
+    end
+
+    puts "Backfill complete. scanned=#{stats[:scanned]} updated=#{stats[:updated]} failed=#{stats[:failed]}"
+
+    if failures.any?
+      FileUtils.mkdir_p(File.dirname(report_path))
+      File.write(report_path, JSON.pretty_generate(failures))
+      puts "Failure report written to #{report_path}"
+    end
+  end
+
+  def derive_target_date(smart_goal)
+    months = SmartGoals::Create::TIMEFRAME_TO_MONTHS[smart_goal.timeframe]
+    return { error: "invalid timeframe '#{smart_goal.timeframe}'" } unless months
+
+    profile = smart_goal.profile
+    return { error: 'missing profile' } unless profile
+
+    timezone = profile.timezone
+    return { error: 'missing profile timezone' } if timezone.blank?
+    return { error: "invalid profile timezone '#{timezone}'" } unless ActiveSupport::TimeZone[timezone]
+
+    anchor = smart_goal.created_at
+    return { error: 'missing created_at' } unless anchor
+
+    target_date = Time.use_zone(timezone) do
+      anchor.in_time_zone.beginning_of_day + months.months
+    end
+
+    { target_date: target_date }
+  end
+
+  def failure_payload(smart_goal, error)
+    {
+      smart_goal_id: smart_goal.id,
+      profile_id: smart_goal.profile_id,
+      timeframe: smart_goal.timeframe,
+      error: error
+    }
+  end
+
+  def default_report_path
+    Rails.root.join('tmp', "smart_goal_target_date_backfill_failures_#{Time.current.utc.strftime('%Y%m%d%H%M%S')}.json")
+  end
+end

--- a/lib/tasks/smart_goals/backfill_target_dates.rake
+++ b/lib/tasks/smart_goals/backfill_target_dates.rake
@@ -40,7 +40,7 @@ namespace :smart_goals do
         end
 
         begin
-          smart_goal.update_columns(target_date: target_date_or_error[:target_date], updated_at: Time.current)
+          smart_goal.update(target_date: target_date_or_error[:target_date], updated_at: Time.current)
           stats[:updated] += 1
         rescue StandardError => e
           stats[:failed] += 1

--- a/spec/rake/task_smart_goals_backfill_target_dates_spec.rb
+++ b/spec/rake/task_smart_goals_backfill_target_dates_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+require 'fileutils'
+
+RSpec.describe Rake::Task, 'smart_goals:backfill_target_dates' do
+  before do
+    Rails.application.load_tasks unless described_class.task_defined?(task_name)
+  end
+
+  let(:task_name) { 'smart_goals:backfill_target_dates' }
+  let(:task) { described_class[task_name] }
+  let(:batch_size) { '100' }
+  let(:dry_run) { 'false' }
+  let(:report_path) { Rails.root.join('tmp', 'smart_goal_backfill_task_spec_failures.json').to_s }
+
+  around do |example|
+    original_batch_size = ENV.fetch('BATCH_SIZE', nil)
+    original_dry_run = ENV.fetch('DRY_RUN', nil)
+    original_report_path = ENV.fetch('REPORT_PATH', nil)
+
+    ENV['BATCH_SIZE'] = batch_size
+    ENV['DRY_RUN'] = dry_run
+    ENV['REPORT_PATH'] = report_path
+
+    example.run
+  ensure
+    ENV['BATCH_SIZE'] = original_batch_size
+    ENV['DRY_RUN'] = original_dry_run
+    ENV['REPORT_PATH'] = original_report_path
+    FileUtils.rm_f(report_path)
+    task.reenable
+  end
+
+  it 'backfills target_date from created_at and profile timezone' do
+    profile = create(:profile, timezone: 'America/Los_Angeles')
+    smart_goal = build(:smart_goal, profile: profile, timeframe: '3_months')
+    smart_goal.assign_attributes(
+      target_date: nil,
+      created_at: Time.utc(2026, 1, 15, 18, 35, 0),
+      updated_at: Time.utc(2026, 1, 15, 18, 35, 0)
+    )
+    smart_goal.save(validate: false)
+
+    task.invoke
+
+    expected = Time.use_zone('America/Los_Angeles') do
+      smart_goal.created_at.in_time_zone.beginning_of_day + 3.months
+    end
+    expect(smart_goal.reload.target_date).to eq(expected)
+  end
+
+  it 'reports rows that cannot be backfilled' do
+    profile = create(:profile)
+    smart_goal = build(:smart_goal, profile: profile, timeframe: 'invalid_timeframe', target_date: nil)
+    smart_goal.save(validate: false)
+
+    task.invoke
+
+    expect(smart_goal.reload.target_date).to be_nil
+    expect(File).to exist(report_path)
+    report = JSON.parse(File.read(report_path))
+    expect(report.first['smart_goal_id']).to eq(smart_goal.id)
+    expect(report.first['error']).to include('invalid timeframe')
+  end
+
+  context 'when DRY_RUN is true' do
+    let(:dry_run) { 'true' }
+
+    it 'does not persist updates' do
+      profile = create(:profile)
+      smart_goal = build(:smart_goal, profile: profile, timeframe: '1_month', target_date: nil)
+      smart_goal.save(validate: false)
+
+      task.invoke
+
+      expect(smart_goal.reload.target_date).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds a production-safe backfill task for legacy `smart_goals` rows where `target_date` is `NULL`. The task computes `target_date` from each goal’s `timeframe`, anchored to `created_at` in the profile timezone, and processes records in batches.
It also adds focused RSpec coverage for the rake task to verify successful backfill behavior, dry-run safety, and failure reporting for invalid rows.
## Changes
- `lib/tasks/smart_goals/backfill_target_dates.rake`
  - Adds `smart_goals:backfill_target_dates` rake task with `BATCH_SIZE`, `DRY_RUN`, and optional `REPORT_PATH` controls.
  - Backfills `target_date` only for null rows and writes a JSON failure report for rows that cannot be derived.
- `spec/rake/task_smart_goals_backfill_target_dates_spec.rb`
  - Covers timezone-aware derivation from `created_at`.
  - Covers invalid timeframe reporting.
  - Covers `DRY_RUN=true` behavior (no persistence).
## Test Plan
- [x] `bundle exec rspec spec/rake/task_smart_goals_backfill_target_dates_spec.` — 3 examples, 0 failures
- [x] `bundle exec rake smart_goals:backfill_target_dates DRY_RUN=true` in staging/prod-like data — verify counts and failure report shape
- [x] `bundle exec rake smart_goals:backfill_target_dates` in production rollout window — verify no unexpected failures
## Additional Notes
- This PR performs the backfill only; DB-level `NOT NULL` enforcement is intentionally deferred to a follow-up migration after data is verified clean.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 257.09ms | ✅ |
| **90th Percentile Latency** | 242.09ms | - |
| **Average Latency** | 99.88ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 633 requests, 633 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 244.80ms | ✅ |
| **90th Percentile Latency** | 234.27ms | - |
| **Average Latency** | 93.36ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 642 requests, 642 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 237.30ms | ✅ |
| **90th Percentile Latency** | 228.99ms | - |
| **Average Latency** | 87.22ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 654 requests, 654 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 222.77ms | ✅ |
| **90th Percentile Latency** | 205.98ms | - |
| **Average Latency** | 86.98ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 651 requests, 434 checks passed, 217 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 239.63ms | ✅ |
| **90th Percentile Latency** | 231.38ms | - |
| **Average Latency** | 89.71ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 648 requests, 648 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1746.94ms | ✅ |
| **90th Percentile Latency** | 1574.65ms | - |
| **Average Latency** | 759.60ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 225.91ms | ✅ |
| **90th Percentile Latency** | 209.44ms | - |
| **Average Latency** | 83.08ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 660 requests, 660 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 255.43ms | ✅ |
| **90th Percentile Latency** | 247.61ms | - |
| **Average Latency** | 99.59ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 642 requests, 428 checks passed, 214 checks failed

---

<!-- PERF_RESULTS_END -->