### PR TITLE
db/adds migration to add notnull constraint to smartgoal targetdate

### DIFF
--- a/db/migrate/20260525121000_make_smart_goals_target_date_not_null.rb
+++ b/db/migrate/20260525121000_make_smart_goals_target_date_not_null.rb
@@ -1,0 +1,5 @@
+class MakeSmartGoalsTargetDateNotNull < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :smart_goals, :target_date, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_25_120001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_25_121000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,7 +138,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_25_120001) do
     t.text "time_bound"
     t.boolean "completed", default: false
     t.bigint "profile_id", null: false
-    t.datetime "target_date"
+    t.datetime "target_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.time "reminder_at", default: "2000-01-01 09:00:00", null: false

--- a/spec/rake/task_smart_goals_backfill_target_dates_spec.rb
+++ b/spec/rake/task_smart_goals_backfill_target_dates_spec.rb
@@ -19,13 +19,17 @@ RSpec.describe Rake::Task, 'smart_goals:backfill_target_dates' do
     original_batch_size = ENV.fetch('BATCH_SIZE', nil)
     original_dry_run = ENV.fetch('DRY_RUN', nil)
     original_report_path = ENV.fetch('REPORT_PATH', nil)
+    connection = ActiveRecord::Base.connection
 
     ENV['BATCH_SIZE'] = batch_size
     ENV['DRY_RUN'] = dry_run
     ENV['REPORT_PATH'] = report_path
+    connection.change_column_null(:smart_goals, :target_date, true)
 
     example.run
   ensure
+    SmartGoal.where(target_date: nil).delete_all
+    connection.change_column_null(:smart_goals, :target_date, false)
     ENV['BATCH_SIZE'] = original_batch_size
     ENV['DRY_RUN'] = original_dry_run
     ENV['REPORT_PATH'] = original_report_path


### PR DESCRIPTION
## Summary
This PR finalizes the SmartGoal target date rollout by enforcing a database-level `NOT NULL` constraint on `smart_goals.target_date` after the backfill phase. This ensures new and existing records cannot persist without a target date, aligning DB guarantees with app-level creation behavior.

It also updates the rake task spec strategy so we can still verify legacy-null backfill behavior in test after the constraint is enforced. The spec temporarily relaxes the constraint within each example, inserts legacy-invalid records, runs the task, and restores the constraint in cleanup.

### Why
The rollout sequence is backfill first, constraint second. This PR is the “constraint + regression safety” step that prevents future data drift while preserving meaningful test coverage for historical data repair.

## Changes
- `db/migrate/20260525121000_make_smart_goals_target_date_not_null.rb`
  - Adds migration to enforce `smart_goals.target_date` as `NOT NULL`.
- `db/schema.rb`
  - Reflectarget_date` as non-null in schema.
- `spec/rake/task_smart_goals_backfill_target_dates_spec.rb`
  - Keeps end-to-end backfill behavior tests valid after constraint enforcement by temporarily toggling nullability in test setup/teardown.
  - Cleans up null test rows before re-enabling the constraint.

## Test Plan
- [ ] `bundle exec rspec spec/rake/task_smart_goals_backfill_target_dates_spec.rb` — verifies backfill, invalid-timeframe reporting, and dry-run behavior under post-migration schema
- [ ] `bundle exec rspec` — verify no regressions across full server suite
- [ ] `bundle exec rails db:migrate` — confirm migration applies cleanly in target environment

## Additional Notes
- This PR intentionally focuses on DB enforcement + test compatibility; it does not change reminder scheduling behavior or service derivation logic.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 274.11ms | ✅ |
| **90th Percentile Latency** | 256.05ms | - |
| **Average Latency** | 101.40ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 636 requests, 636 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 248.73ms | ✅ |
| **90th Percentile Latency** | 240.32ms | - |
| **Average Latency** | 97.11ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 642 requests, 642 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 252.97ms | ✅ |
| **90th Percentile Latency** | 238.58ms | - |
| **Average Latency** | 90.43ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 651 requests, 651 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 226.91ms | ✅ |
| **90th Percentile Latency** | 211.25ms | - |
| **Average Latency** | 86.56ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 651 requests, 434 checks passed, 217 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 247.53ms | ✅ |
| **90th Percentile Latency** | 237.13ms | - |
| **Average Latency** | 93.74ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1790.22ms | ✅ |
| **90th Percentile Latency** | 1646.61ms | - |
| **Average Latency** | 818.45ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 234.74ms | ✅ |
| **90th Percentile Latency** | 217.53ms | - |
| **Average Latency** | 85.15ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 657 requests, 657 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 270.86ms | ✅ |
| **90th Percentile Latency** | 262.71ms | - |
| **Average Latency** | 107.09ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 633 requests, 422 checks passed, 211 checks failed

---

<!-- PERF_RESULTS_END -->