### PR TITLE
refact/reminderat to be nullable and datetime

### DIFF
--- a/db/migrate/20260525232400_make_tasks_reminder_at_nullable.rb
+++ b/db/migrate/20260525232400_make_tasks_reminder_at_nullable.rb
@@ -1,0 +1,6 @@
+class MakeTasksReminderAtNullable < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :tasks, :reminder_at, from: "2000-01-01 09:00:00", to: nil
+    change_column_null :tasks, :reminder_at, true
+  end
+end

--- a/db/migrate/20260525232700_change_tasks_reminder_at_to_datetime.rb
+++ b/db/migrate/20260525232700_change_tasks_reminder_at_to_datetime.rb
@@ -1,0 +1,18 @@
+class ChangeTasksReminderAtToDatetime < ActiveRecord::Migration[7.2]
+  def up
+    change_column_default :tasks, :reminder_at, nil
+    change_column_null :tasks, :reminder_at, true
+
+    change_column :tasks,
+                  :reminder_at,
+                  :datetime,
+                  using: "CASE WHEN reminder_at IS NULL THEN NULL ELSE (CURRENT_DATE + reminder_at)::timestamp END"
+  end
+
+  def down
+    change_column :tasks, :reminder_at, :time, using: "reminder_at::time"
+    execute "UPDATE tasks SET reminder_at = '09:00:00' WHERE reminder_at IS NULL"
+    change_column_null :tasks, :reminder_at, false
+    change_column_default :tasks, :reminder_at, "09:00:00"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_25_121000) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_25_232700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -156,7 +156,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_25_121000) do
     t.integer "priority"
     t.bigint "smart_goal_id"
     t.datetime "due_at"
-    t.time "reminder_at", default: "2000-01-01 09:00:00", null: false
+    t.datetime "reminder_at"
     t.index ["profile_id"], name: "index_tasks_on_profile_id"
     t.index ["smart_goal_id"], name: "index_tasks_on_smart_goal_id"
   end

--- a/spec/requests/api/v1/tasks_controller_spec.rb
+++ b/spec/requests/api/v1/tasks_controller_spec.rb
@@ -151,6 +151,47 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
       end
     end
 
+    context 'with due_at and reminder_at combinations' do
+      let(:base_task_params) do
+        {
+          title: 'Task with scheduling fields',
+          action_category: 'do'
+        }
+      end
+
+      it 'can be created without reminder_at' do
+        post api_v1_tasks_path, params: { task: base_task_params.merge(due_at: '2026-06-25T22:12:35.364Z') }
+
+        expect(response).to have_http_status(:created)
+        created_task = Task.order(:id).last
+        expect(created_task.reminder_at).to be_nil
+      end
+
+      it 'can be created with reminder_at' do
+        post api_v1_tasks_path, params: { task: base_task_params.merge(reminder_at: '2026-06-25T09:30:00.000Z') }
+
+        expect(response).to have_http_status(:created)
+        created_task = Task.order(:id).last
+        expect(created_task.reminder_at).to be_present
+      end
+
+      it 'can be created without due_at' do
+        post api_v1_tasks_path, params: { task: base_task_params.merge(reminder_at: '2026-06-25T09:30:00.000Z') }
+
+        expect(response).to have_http_status(:created)
+        created_task = Task.order(:id).last
+        expect(created_task.due_at).to be_nil
+      end
+
+      it 'can be created with due_at' do
+        post api_v1_tasks_path, params: { task: base_task_params.merge(due_at: '2026-06-25T22:12:35.364Z') }
+
+        expect(response).to have_http_status(:created)
+        created_task = Task.order(:id).last
+        expect(created_task.due_at).to be_present
+      end
+    end
+
     context 'with invalid parameters' do
       context 'when title is missing' do
         let(:invalid_params) do
@@ -282,6 +323,44 @@ RSpec.describe 'Api::V1::Tasks', type: :request do
 
         expect(json_response['completed']).to be(true)
         expect(json_response['title']).to eq(original_title)
+      end
+    end
+
+    context 'with due_at and reminder_at updates' do
+      it 'can be updated with due_at' do
+        patch api_v1_task_path(task), params: { task: { due_at: '2026-06-25T22:12:35.364Z' } }
+
+        expect(response).to have_http_status(:ok)
+        task.reload
+        expect(task.due_at).to be_present
+      end
+
+      it 'can clear due_at' do
+        task.update!(due_at: Time.zone.parse('2026-06-25T22:12:35.364Z'))
+
+        patch api_v1_task_path(task), params: { task: { due_at: nil } }
+
+        expect(response).to have_http_status(:ok)
+        task.reload
+        expect(task.due_at).to be_nil
+      end
+
+      it 'can be updated with reminder_at' do
+        patch api_v1_task_path(task), params: { task: { reminder_at: '2026-06-25T09:30:00.000Z' } }
+
+        expect(response).to have_http_status(:ok)
+        task.reload
+        expect(task.reminder_at).to be_present
+      end
+
+      it 'can clear reminder_at' do
+        task.update!(reminder_at: Time.zone.parse('2026-06-25T09:30:00.000Z'))
+
+        patch api_v1_task_path(task), params: { task: { reminder_at: nil } }
+
+        expect(response).to have_http_status(:ok)
+        task.reload
+        expect(task.reminder_at).to be_nil
       end
     end
 


### PR DESCRIPTION
## Summary
Make `tasks.reminder_at` optional and migrate it from `time` to `datetime` so task scheduling fields can be stored as full timestamps and cleared when unset.

## Changes
- `server/db/migrate/20260525232400_make_tasks_reminder_at_nullable.rb`
  - Removes `NOT NULL` constraint from `tasks.reminder_at`
  - Removes default value for `tasks.reminder_at`
- `server/db/migrate/20260525232700_change_tasks_reminder_at_to_datetime.rb`
  - Converts `tasks.reminder_at` from `time` to `datetime`
  - Safely migrates existing non-null values using SQL cast logic
  - Includes reversible `down` migration (type revert + null/default restoration)
- `server/spec/requests/api/v1/tasks_controller_spec.rb`
  - Adds create coverage for:
    - without `reminder_at`
    - with `reminder_at`
    - without `due_at`
    - with `due_at`
  - Adds update coverage for:
    - setting `due_at`
    - clearing `due_at`
    - setting `reminder_at`
    - clearing `reminder_at`

## Test Plan
- [ ] `cd server && bin/rails db:migrate`
- [ ] `cd server && bundle exec rspec spec/requests/api/v1/tasks_controller_spec.rb`
- [ ] Verify create/update requests accept `nil` and datetime values for `reminder_at` and `due_at` as expected

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 283.19ms | ✅ |
| **90th Percentile Latency** | 266.73ms | - |
| **Average Latency** | 115.32ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 630 requests, 630 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 267.43ms | ✅ |
| **90th Percentile Latency** | 259.88ms | - |
| **Average Latency** | 99.54ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 246.20ms | ✅ |
| **90th Percentile Latency** | 241.02ms | - |
| **Average Latency** | 93.67ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 642 requests, 642 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 240.74ms | ✅ |
| **90th Percentile Latency** | 232.54ms | - |
| **Average Latency** | 91.75ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 648 requests, 432 checks passed, 216 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 245.73ms | ✅ |
| **90th Percentile Latency** | 239.92ms | - |
| **Average Latency** | 101.30ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 639 requests, 639 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1863.12ms | ✅ |
| **90th Percentile Latency** | 1634.32ms | - |
| **Average Latency** | 833.76ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 231.21ms | ✅ |
| **90th Percentile Latency** | 211.79ms | - |
| **Average Latency** | 89.76ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 651 requests, 651 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 291.98ms | ✅ |
| **90th Percentile Latency** | 283.57ms | - |
| **Average Latency** | 116.60ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 621 requests, 414 checks passed, 207 checks failed

---

<!-- PERF_RESULTS_END -->