### PR TITLE
fix: onboarding endpoints — nested params + habits index

### DIFF
--- a/app/controllers/api/v1/habit_completions_controller.rb
+++ b/app/controllers/api/v1/habit_completions_controller.rb
@@ -6,14 +6,16 @@ module Api
       before_action :authenticate_api_v1_user!
 
       def create
-        habit = current_api_v1_profile.habits.find_by(id: params[:habit_id])
+        attrs = habit_completion_params
+        habit = current_api_v1_profile.habits.find_by(id: attrs[:habit_id])
         return render json: { error: 'Habit not found' }, status: :not_found unless habit
 
-        completed_on = parse_date(params[:completed_on]) || Date.current
+        completed_on = parse_date(attrs[:completed_on]) || Date.current
 
         completion = habit.habit_completions.find_or_create_by!(completed_on: completed_on) do |c|
-          c.state = params[:state].presence || 'committed'
+          c.state = attrs[:state].presence || 'committed'
           c.committed_at = Time.current
+          c.note = attrs[:note] if attrs[:note].present?
         end
 
         render json: completion, status: :ok
@@ -22,6 +24,10 @@ module Api
       end
 
       private
+
+      def habit_completion_params
+        params.require(:habit_completion).permit(:habit_id, :completed_on, :state, :note)
+      end
 
       def parse_date(value)
         return nil if value.blank?

--- a/app/controllers/api/v1/habits_controller.rb
+++ b/app/controllers/api/v1/habits_controller.rb
@@ -7,6 +7,12 @@ module Api
 
       before_action :authenticate_api_v1_user!
 
+      def index
+        habits = current_api_v1_profile.habits.active.order(:position)
+        habits = habits.where(smart_goal_id: params[:smart_goal_id]) if params[:smart_goal_id].present?
+        render json: habits
+      end
+
       def create
         smart_goal = current_api_v1_profile.smart_goals.find_by(id: params[:smart_goal_id])
         return render_not_found('SmartGoal not found') unless smart_goal

--- a/app/controllers/api/v1/notification_schedules_controller.rb
+++ b/app/controllers/api/v1/notification_schedules_controller.rb
@@ -7,22 +7,30 @@ module Api
 
       def create
         profile = current_api_v1_profile
-        kind = params[:kind].presence || 'daily_check_in'
+        attrs = notification_schedule_params
+        kind = attrs[:kind].presence || 'daily_check_in'
+        active = attrs.key?(:active) ? attrs[:active] : true
 
         schedule = nil
         NotificationSchedule.transaction do
           profile.notification_schedules.where(kind: kind, active: true).update_all(active: false) # rubocop:disable Rails/SkipsModelValidations
           schedule = profile.notification_schedules.create!(
             kind: kind,
-            local_time: params[:local_time],
-            timezone: params[:timezone],
-            active: params.fetch(:active, true)
+            local_time: attrs[:local_time],
+            timezone: attrs[:timezone],
+            active: active
           )
         end
 
         render json: schedule, status: :created
       rescue ActiveRecord::RecordInvalid => e
         render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
+      end
+
+      private
+
+      def notification_schedule_params
+        params.require(:notification_schedule).permit(:kind, :local_time, :timezone, :active)
       end
     end
   end

--- a/app/controllers/api/v1/smart_goals_controller.rb
+++ b/app/controllers/api/v1/smart_goals_controller.rb
@@ -48,7 +48,8 @@ module Api
       def create_smart_goal_params
         params.require(:smart_goal).permit(
           :title, :description, :timeframe, :specific, :measurable,
-          :achievable, :relevant, :time_bound, :completed
+          :achievable, :relevant, :time_bound, :completed,
+          :primary, :why, :target_date
         )
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       resources :device_tokens, only: %i[create destroy]
       resource :notification_preferences, only: %i[show update]
 
-      resources :habits, only: %i[create]
+      resources :habits, only: %i[index create]
       resources :habit_completions, only: %i[create]
       resources :notification_schedules, only: %i[create]
 

--- a/spec/requests/api/v1/habit_completions_controller_spec.rb
+++ b/spec/requests/api/v1/habit_completions_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Api::V1::HabitCompletions', type: :request do
 
   describe 'POST /api/v1/habit_completions' do
     it 'creates a committed completion for today by default' do
-      expect { post api_v1_habit_completions_path, params: { habit_id: habit.id }, as: :json }
+      expect { post api_v1_habit_completions_path, params: { habit_completion: { habit_id: habit.id } }, as: :json }
         .to change(HabitCompletion, :count).by(1)
 
       expect(response).to have_http_status(:ok)
@@ -23,7 +23,7 @@ RSpec.describe 'Api::V1::HabitCompletions', type: :request do
     it 'is idempotent on repeat (habit_id, completed_on)' do
       existing = create(:habit_completion, habit: habit, completed_on: Date.current)
 
-      expect { post api_v1_habit_completions_path, params: { habit_id: habit.id }, as: :json }
+      expect { post api_v1_habit_completions_path, params: { habit_completion: { habit_id: habit.id } }, as: :json }
         .not_to(change(HabitCompletion, :count))
 
       expect(response).to have_http_status(:ok)
@@ -33,7 +33,7 @@ RSpec.describe 'Api::V1::HabitCompletions', type: :request do
     it 'returns not found for another user\'s habit' do
       other_habit = create(:habit, profile: create(:user).profile)
 
-      post api_v1_habit_completions_path, params: { habit_id: other_habit.id }, as: :json
+      post api_v1_habit_completions_path, params: { habit_completion: { habit_id: other_habit.id } }, as: :json
 
       expect(response).to have_http_status(:not_found)
     end

--- a/spec/requests/api/v1/habits_controller_spec.rb
+++ b/spec/requests/api/v1/habits_controller_spec.rb
@@ -79,4 +79,39 @@ RSpec.describe 'Api::V1::Habits', type: :request do
       expect(response.parsed_body['errors']).to be_present
     end
   end
+
+  describe 'GET /api/v1/habits' do
+    let!(:habit1) { create(:habit, profile: profile, smart_goal: smart_goal, position: 1) }
+    let!(:habit2) { create(:habit, profile: profile, smart_goal: smart_goal, position: 2) }
+
+    it 'returns the profile\'s active habits ordered by position' do
+      archived = create(:habit, profile: profile, smart_goal: smart_goal, position: 3)
+      archived.update!(archived_at: Time.current)
+
+      get api_v1_habits_path
+
+      expect(response).to have_http_status(:ok)
+      ids = response.parsed_body.pluck('id')
+      expect(ids).to eq([habit1.id, habit2.id])
+    end
+
+    it 'scopes results to smart_goal_id when provided' do
+      other_goal = create(:smart_goal, profile: profile)
+      create(:habit, profile: profile, smart_goal: other_goal, position: 1)
+
+      get api_v1_habits_path, params: { smart_goal_id: smart_goal.id }
+
+      expect(response.parsed_body.pluck('smart_goal_id').uniq).to eq([smart_goal.id])
+    end
+
+    it 'does not return another profile\'s habits' do
+      other_profile = create(:user).profile
+      other_goal = create(:smart_goal, profile: other_profile)
+      create(:habit, profile: other_profile, smart_goal: other_goal, position: 1)
+
+      get api_v1_habits_path
+
+      expect(response.parsed_body.pluck('id')).to contain_exactly(habit1.id, habit2.id)
+    end
+  end
 end

--- a/spec/requests/api/v1/notification_schedules_controller_spec.rb
+++ b/spec/requests/api/v1/notification_schedules_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Api::V1::NotificationSchedules', type: :request do
   describe 'POST /api/v1/notification_schedules' do
     it 'creates an active daily_check_in schedule' do
       post api_v1_notification_schedules_path,
-           params: { local_time: '07:00', timezone: 'America/Los_Angeles' },
+           params: { notification_schedule: { local_time: '07:00', timezone: 'America/Los_Angeles' } },
            as: :json
 
       expect(response).to have_http_status(:created)
@@ -22,7 +22,7 @@ RSpec.describe 'Api::V1::NotificationSchedules', type: :request do
       first = create(:notification_schedule, profile: profile, local_time: '08:00', active: true)
 
       post api_v1_notification_schedules_path,
-           params: { local_time: '12:00', timezone: 'UTC' },
+           params: { notification_schedule: { local_time: '12:00', timezone: 'UTC' } },
            as: :json
 
       expect(response).to have_http_status(:created)
@@ -32,7 +32,7 @@ RSpec.describe 'Api::V1::NotificationSchedules', type: :request do
 
     it 'rejects invalid timezone' do
       post api_v1_notification_schedules_path,
-           params: { local_time: '07:00', timezone: 'Not/AZone' },
+           params: { notification_schedule: { local_time: '07:00', timezone: 'Not/AZone' } },
            as: :json
 
       expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/api/v1/smart_goals_controller_spec.rb
+++ b/spec/requests/api/v1/smart_goals_controller_spec.rb
@@ -217,6 +217,18 @@ RSpec.describe 'Api::V1::SmartGoals', type: :request do
         end
       end
 
+      it 'persists primary and why when provided (needed for onboarding resume)' do
+        params_with_primary = valid_params.deep_merge(
+          smart_goal: { primary: true, why: 'because it matters' }
+        )
+
+        post api_v1_smart_goals_path, params: params_with_primary
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body['primary']).to be(true)
+        expect(response.parsed_body['why']).to eq('because it matters')
+      end
+
       it 'ignores any client-supplied target_date and derives its own' do
         bogus = 10.years.from_now.to_date.iso8601
         params_with_target = valid_params.deep_merge(smart_goal: { target_date: bogus })


### PR DESCRIPTION
## Summary

Fixes two issues surfaced while running the V2 onboarding wizard on device.

**Nested strong params on completion + schedule controllers.** `HabitCompletionsController#create` and `NotificationSchedulesController#create` were reading their inputs off `params` at the top level, but the client sends them nested under `habit_completion` / `notification_schedule` keys (Rails convention). The result was `params[:habit_id]` etc. resolving to `nil`, producing a 404 on Step 3 → 4 and a 422 on Step 4 → 5. Both controllers now use dedicated strong-params methods and the request specs post the nested payload.

**Habits index endpoint.** `GET /api/onboarding/resume` returns `habit_ids` when the user is mid-wizard, but there was no way for the client to hydrate those into `Habit` records — meaning Step 3 (Today's Action) can't rebuild its UI on relaunch. Adds `GET /api/v1/habits` (profile-scoped, optionally filtered by `smart_goal_id`) so the client can pull the habits it already knows the ids for.

### Why

Both showed up in on-device testing of the F3 client PR. The strong-params issues were blocking the wizard from ever reaching its final steps; the missing index endpoint was silently forcing the client to fall back to Step 2 on any mid-wizard relaunch.

## Changes

- `app/controllers/api/v1/habit_completions_controller.rb`
  - Add `habit_completion_params` (permits `habit_id`, `completed_on`, `state`, `note`) and read all values through it.
- `app/controllers/api/v1/notification_schedules_controller.rb`
  - Add `notification_schedule_params` (permits `kind`, `local_time`, `timezone`, `active`) and read all values through it.
- `app/controllers/api/v1/habits_controller.rb`
  - Add `index` action returning the current profile's active habits ordered by position, filterable by `smart_goal_id`.
- `config/routes.rb`
  - `resources :habits, only: %i[index create]`.
- `spec/requests/api/v1/habit_completions_controller_spec.rb`, `spec/requests/api/v1/notification_schedules_controller_spec.rb`
  - Update the 3 + 3 posts to the nested payload shape.
- `spec/requests/api/v1/habits_controller_spec.rb`
  - Three new index specs: ordering + archived exclusion, `smart_goal_id` scoping, cross-profile isolation.

## Test Plan

- [x] \`bundle exec rspec\` — 656 examples, 0 failures.
- [x] \`bundle exec erb_lint --lint-all\` — clean.
- [x] \`bundle exec rubocop\` — 0 offenses.
- [ ] Manual with the client V2 wizard: Step 3 → 4 tap creates a `HabitCompletion(committed)`; Step 4 → 5 tap creates a `NotificationSchedule` and flips \`onboarding_version = "v2"\`.
- [ ] Manual: kill-and-relaunch mid-wizard once the client wires up \`GET /api/habits\` (follow-up); Step 3 resume should render the three habits instead of falling back to Step 2.

## Additional Notes

- Client fix that consumes this branch: [personal-coach-client#27](https://github.com/J-pilon/personal-coach-client/pull/27). That PR already parses the server's string \`current_step\` values from \`/api/onboarding/resume\`, so the resume flow works end-to-end for Steps 4 and 5 as soon as this ships; Step 3 hydration is a follow-up on the client side.

<!-- PERF_RESULTS_START -->
## 🚀 Performance Test Results

### Get Jobs Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 264.65ms | ✅ |
| **90th Percentile Latency** | 232.93ms | - |
| **Average Latency** | 98.49ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 636 requests, 636 checks passed, 0 checks failed

---

### Get Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 238.74ms | ✅ |
| **90th Percentile Latency** | 230.56ms | - |
| **Average Latency** | 101.18ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 636 requests, 636 checks passed, 0 checks failed

---

### Get Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 234.64ms | ✅ |
| **90th Percentile Latency** | 222.80ms | - |
| **Average Latency** | 88.72ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 651 requests, 651 checks passed, 0 checks failed

---

### Post Ai Proxy Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 216.57ms | ✅ |
| **90th Percentile Latency** | 200.90ms | - |
| **Average Latency** | 79.28ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 666 requests, 444 checks passed, 222 checks failed

---

### Post Ai Suggested Tasks Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 244.88ms | ✅ |
| **90th Percentile Latency** | 226.01ms | - |
| **Average Latency** | 91.54ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 648 requests, 648 checks passed, 0 checks failed

---

### Post Ai Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 1834.03ms | ✅ |
| **90th Percentile Latency** | 1663.14ms | - |
| **Average Latency** | 802.15ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 300 requests, 200 checks passed, 100 checks failed

---

### Post Ai Usage Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 228.94ms | ✅ |
| **90th Percentile Latency** | 210.88ms | - |
| **Average Latency** | 85.92ms | - |
| **Failure Rate** | 0% | ✅ |

**Summary:** 648 requests, 648 checks passed, 0 checks failed

---

### Post Smart Goals Test

| Metric | Value | Status |
|--------|-------|--------|
| **95th Percentile Latency** | 247.73ms | ✅ |
| **90th Percentile Latency** | 240.75ms | - |
| **Average Latency** | 97.71ms | - |
| **Failure Rate** | 33.3333333333333300% | ❌ |

**Summary:** 642 requests, 428 checks passed, 214 checks failed

---

<!-- PERF_RESULTS_END -->